### PR TITLE
fix: hide useless information and use PF link

### DIFF
--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -1,11 +1,23 @@
 class Champs::SiretChamp < Champ
   include SiretChampEtablissementFetchableConcern
 
+  validate :validate_siret_length
+
   def search_terms
     etablissement.present? ? etablissement.search_terms : [value]
   end
 
   def mandatory_blank?
     mandatory? && Siret.new(siret: value).invalid?
+  end
+
+  private
+
+  def validate_siret_length
+    return if value.blank?
+
+    if value.length < 9
+      errors.add(:value, "Le Numéro Tahiti doit comporter au moins 9 chiffres, selectionnez une proposition dans la liste.")
+    end
   end
 end

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -17,7 +17,7 @@ class Champs::SiretChamp < Champ
     return if value.blank?
 
     if value.length < 9
-      errors.add(:value, "Le Numéro Tahiti doit comporter au moins 9 chiffres, selectionnez une proposition dans la liste.")
+      errors.add(:value, "Veuillez selectionner un des établissements")
     end
   end
 end

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -57,21 +57,21 @@
                   = humanized_entreprise_etat_administratif(etablissement)
 
         - if profile == 'instructeur'
-          = render Dossiers::RowShowComponent.new(label: "Effectif mensuel #{try_format_mois_effectif(etablissement)} de l'établissement (URSSAF ou MSA)") do |c|
-            - c.with_value do
-              %p= etablissement.entreprise_effectif_mensuel
-
-          = render Dossiers::RowShowComponent.new(label: "Effectif moyen annuel #{etablissement.entreprise_effectif_annuel_annee} de l'unité légale (URSSAF ou MSA)") do |c|
-            - c.with_value do
-              %p= etablissement.entreprise_effectif_annuel
+          -# = render Dossiers::RowShowComponent.new(label: "Effectif mensuel #{try_format_mois_effectif(etablissement)} de l'établissement (URSSAF ou MSA)") do |c|
+          -#   - c.with_value do
+          -#     %p= etablissement.entreprise_effectif_mensuel
+          -#
+          -# = render Dossiers::RowShowComponent.new(label: "Effectif moyen annuel #{etablissement.entreprise_effectif_annuel_annee} de l'unité légale (URSSAF ou MSA)") do |c|
+          -#   - c.with_value do
+          -#     %p= etablissement.entreprise_effectif_annuel
 
           = render Dossiers::RowShowComponent.new(label: "Effectif de l’organisation (INSEE)") do |c|
             - c.with_value do
               %p= effectif(etablissement)
 
-          = render Dossiers::RowShowComponent.new(label: "Numéro de TVA intracommunautaire") do |c|
-            - c.with_value do
-              %p= etablissement.entreprise.numero_tva_intracommunautaire
+          -# = render Dossiers::RowShowComponent.new(label: "Numéro de TVA intracommunautaire") do |c|
+          -#   - c.with_value do
+          -#     %p= etablissement.entreprise.numero_tva_intracommunautaire
 
           = render Dossiers::RowShowComponent.new(label: "Adresse") do |c|
             - c.with_value do
@@ -80,21 +80,21 @@
                   = line
                   %br
 
-          = render Dossiers::RowShowComponent.new(label: "Capital social") do |c|
-            - c.with_value do
-              %p= pretty_currency(etablissement.entreprise.capital_social)
+          -# = render Dossiers::RowShowComponent.new(label: "Capital social") do |c|
+          -#   - c.with_value do
+          -#     %p= pretty_currency(etablissement.entreprise.capital_social)
 
-        - if etablissement.exercices.any?
-          = render Dossiers::RowShowComponent.new(label: "Chiffre d’affaires") do |c|
-            - c.with_value do
-              - if profile == 'instructeur'
-                %details
-                  - etablissement.exercices.each_with_index do |exercice, index|
-                    = "#{exercice.date_fin_exercice.year} : "
-                    = pretty_currency(exercice.ca)
-                    %br
-              - elsif etablissement.exercices.present?
-                = t('activemodel.models.exercices_summary', count: etablissement.exercices.count)
+        -# - if etablissement.exercices.any?
+        -#   = render Dossiers::RowShowComponent.new(label: "Chiffre d’affaires") do |c|
+        -#     - c.with_value do
+        -#       - if profile == 'instructeur'
+        -#         %details
+        -#           - etablissement.exercices.each_with_index do |exercice, index|
+        -#             = "#{exercice.date_fin_exercice.year} : "
+        -#             = pretty_currency(exercice.ca)
+        -#             %br
+        -#       - elsif etablissement.exercices.present?
+        -#         = t('activemodel.models.exercices_summary', count: etablissement.exercices.count)
 
         - if etablissement.entreprise_bilans_bdf.present?
           - if profile == 'instructeur'

--- a/app/views/users/dossiers/siret.html.haml
+++ b/app/views/users/dossiers/siret.html.haml
@@ -17,6 +17,6 @@
 
         .fr-fieldset__element
           %p.fr-text--sm= t('views.users.dossiers.identite.siret_help_html',
-                            annuaire_link: link_to('annuaire-entreprises.data.gouv.fr', annuaire_link, title: new_tab_suffix(t('views.users.dossiers.identite.annuaire_link_title')), **external_link_attributes))
+                            annuaire_link: link_to('ispf.pf/rte', annuaire_link, title: new_tab_suffix(t('views.users.dossiers.identite.annuaire_link_title')), **external_link_attributes))
 
       = f.submit t('views.users.dossiers.identite.continue'), class: "fr-btn", data: { disable_with: t('views.users.dossiers.identite.siret_loading') }

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,1 +1,1 @@
-SIRET_LENGTH = 6 # 6 for TAHITI number, 14 for SIRET number
+SIRET_LENGTHS = [9, 14] # Updated lengths for TAHITI and SIRET numbers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -746,7 +746,7 @@ en:
       dossier_not_found: "The file does not exist or you do not have access to it."
       # # dossier_map_not_activated: "The file does not have access to the map."
       targeted_user_link_expired: "This invitation link or the file is no longer available."
-      invalid_siret_length: "The TAHITI number must contain exactly 6 characters."
+      invalid_siret_length: "The TAHITI number must contain exactly 9 or 14 characters."
       invalid_siret_checksum: "The TAHITI number is invalid."
       procedure_not_found: "The procedure does not exist"
       siret_unknown: 'We did not find any establishment registered under this TAHITI number.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -750,7 +750,7 @@ fr:
       dossier_not_found: "Le dossier n’existe pas ou vous n’y avez pas accès."
       # dossier_map_not_activated: "Le dossier n’a pas accès à la cartographie."
       targeted_user_link_expired: "Ce lien d’invitation n’est plus valable ou le dossier n’est plus accessible."
-      invalid_siret_length: "Le numéro TAHITI doit comporter exactement 6 caractères."
+      invalid_siret_length: "Le numéro TAHITI doit comporter exactement 9 ou 14 caractères."
       invalid_siret_checksum: "Le format du numéro TAHITI est invalide."
       procedure_not_found: "La démarche n’existe pas"
       siret_unknown: 'Nous n’avons pas trouvé d’établissement enregistré correspondant à ce numéro TAHITI.'

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -61,7 +61,7 @@ describe Champs::SiretController, type: :controller do
         end
 
         it 'displays a “SIRET is invalid” error message' do
-          expect(response.body).to include("Le numéro TAHITI doit comporter exactement #{SIRET_LENGTH} caractères.")
+          expect(response.body).to include("Le numéro TAHITI doit comporter exactement 9 ou 14 caractères.")
         end
       end
 
@@ -135,7 +135,7 @@ describe Champs::SiretController, type: :controller do
       end
 
       context 'when the Numéro TAHITI is valid but unknown', vcr: { cassette_name: 'pf_api_entreprise_not_found' } do
-        let(:siret) { '111111' }
+        let(:siret) { '111111111' }
         let(:api_etablissement_status) { 404 }
 
         subject! { get :show, params: params, format: :turbo_stream }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1558,21 +1558,22 @@ describe Dossier, type: :model do
 
       before do
         champ_siret.update(value: '44011762001530')
+        champ_siret.valid?
       end
 
       it 'should not have errors' do
-        expect(errors).to be_empty
+        expect(champ_siret.errors).to be_empty
       end
 
       context "and invalid SIRET" do
         before do
           champ_siret.update(value: "1234")
-          dossier.reload
+          champ_siret.valid?
         end
 
         it 'should have errors' do
-          expect(errors).not_to be_empty
-          expect(errors.first.full_message).to eq("doit être rempli")
+          expect(champ_siret.errors).not_to be_empty
+          expect(champ_siret.errors.first.full_message).to eq("Le Numéro Tahiti doit comporter au moins 9 chiffres, selectionnez une proposition dans la liste.")
         end
       end
     end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1573,7 +1573,7 @@ describe Dossier, type: :model do
 
         it 'should have errors' do
           expect(champ_siret.errors).not_to be_empty
-          expect(champ_siret.errors.first.full_message).to eq("Le Numéro Tahiti doit comporter au moins 9 chiffres, selectionnez une proposition dans la liste.")
+          expect(champ_siret.errors.first.full_message).to eq("Veuillez selectionner un des établissements")
         end
       end
     end


### PR DESCRIPTION
Resolve : 

1. ETQ Instructeur, les informations affichées pour un numéro Tahiti devraient être adaptées à la Polynésie (bug) #7 
2. ETQ Usager, sur un champ numéro Tahiti, MD devrait m'afficher une erreur si j'ai entré 6 chiffres au lieu de 9 #27 

This pull request introduces several changes to the handling and validation of SIRET numbers, updates to the user interface, and modifications to test cases and constants. The most important changes include adding validation for SIRET length, updating the user interface to comment out certain fields, and updating constants and translations for SIRET length.

### Validation and Constants Updates:
* [`app/models/champs/siret_champ.rb`](diffhunk://#diff-62ff71b1c6c644ff9803ff75b765070181bfb6a3092113e8053167d077327b4aR4-R22): Added a private method `validate_siret_length` to ensure the SIRET number has at least 9 characters.
* [`config/initializers/constants.rb`](diffhunk://#diff-26e92494e4d27acd77fb3283341885533a9181e51caf48eb493a7c74a2e9962aL1-R1): Updated `SIRET_LENGTHS` to include both 9 and 14 as valid lengths for TAHITI and SIRET numbers.
* `config/locales/en.yml` and `config/locales/fr.yml`: Updated the error message for invalid SIRET length to reflect the new valid lengths (9 or 14 characters). [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7L749-R749) [[2]](diffhunk://#diff-2c5ab6165f7efe573a84107e0e51102ad47cefb0c65629759d7458eee14326e7L753-R753)

### User Interface Changes:
* [`app/views/shared/dossiers/_identite_entreprise.html.haml`](diffhunk://#diff-9e6f8a833ed3142e6b4fc0ee7739d1aadda89bc06304970d31faf517b9bfeab1L60-R74): Commented out several fields related to entreprise effectif, TVA number, capital social, and chiffre d’affaires. [[1]](diffhunk://#diff-9e6f8a833ed3142e6b4fc0ee7739d1aadda89bc06304970d31faf517b9bfeab1L60-R74) [[2]](diffhunk://#diff-9e6f8a833ed3142e6b4fc0ee7739d1aadda89bc06304970d31faf517b9bfeab1L83-R97)
* [`app/views/users/dossiers/siret.html.haml`](diffhunk://#diff-b8c4ce51645487acacc0442b1add4db08a4011f7499ed77a2c92cd8634ffe5f5L20-R20): Updated the link in the help text to point to `ispf.pf/rte` instead of `annuaire-entreprises.data.gouv.fr`.

### Test Case Updates:
* [`spec/controllers/champs/siret_controller_spec.rb`](diffhunk://#diff-4494330d12b54465073035ab7775e372db2fc87cd87c04d0c5c44e67ab80706fL64-R64): Updated test cases to reflect the new valid SIRET lengths and corrected the expected error message. [[1]](diffhunk://#diff-4494330d12b54465073035ab7775e372db2fc87cd87c04d0c5c44e67ab80706fL64-R64) [[2]](diffhunk://#diff-4494330d12b54465073035ab7775e372db2fc87cd87c04d0c5c44e67ab80706fL138-R138)
* [`spec/models/dossier_spec.rb`](diffhunk://#diff-7d4c07244786d0e873a58b9a96e3bdbf1e8945aed177f302c982b4eb6498bc39R1561-R1576): Modified test cases to validate the new SIRET length requirements and ensure proper error messages are displayed.
