### PR TITLE
Fix/load tefenua repetable bloc

### DIFF
--- a/app/javascript/new_design/champs/te_fenua.js
+++ b/app/javascript/new_design/champs/te_fenua.js
@@ -27,20 +27,31 @@ import {
 const MAPS = new WeakMap();
 let MARKER_PATH = '';
 
+function initializeTeFenuaMap(container) {
+  const elements = container.querySelectorAll(
+    '.te-fenua:not([data-initialized])'
+  );
+
+  elements.forEach((element) => {
+    if (element.closest('.te-fenua[data-initialized]')) {
+      // on ignore les cartes déjà initialisée
+      return;
+    }
+
+    let map = displayMap(element);
+    MAPS.set(element, map);
+    element.setAttribute('data-initialized', 'true');
+  });
+}
+
 // Initialise la carte TeFenua quand le DOM est prêt
 async function initialize() {
-  const elements = document.querySelectorAll('.te-fenua');
+  const elements = document.querySelectorAll('.te-fenua:not([data-initialized])');
+  initializeTeFenuaMap(document);
 
   window.viewOnMap = viewOnMap;
 
-  if (elements.length) {
-    // await loadOpenLayers(false);
-
-    for (let element of elements) {
-      let map = displayMap(element, true);
-      MAPS.set(element, map);
-    }
-  }
+  elements.forEach((element) => {})
 
   // delegate('change', '[data-te-fenua-place]', (event) => {
   //   let map = getMapFromAddress(event.target);
@@ -461,6 +472,35 @@ function displayMap(mapElement) {
 
   return map;
 }
+
+// Écouteur générique pour mutations du DOM (attrape les cas non gérés par Turbo)
+document.addEventListener('DOMContentLoaded', () => {
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.addedNodes.length) {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            if (node.classList && node.classList.contains('te-fenua')) {
+              let map = displayMap(node, true);
+              MAPS.set(node, map);
+              node.setAttribute('data-initialized', 'true');
+            }
+
+            // Vérifier aussi les sous-éléments
+            if (node.querySelectorAll) {
+              initializeTeFenuaMap(node);
+            }
+          }
+        });
+      }
+    });
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
+});
 
 addEventListener('DOMContentLoaded', initialize);
 

--- a/app/javascript/new_design/champs/te_fenua.js
+++ b/app/javascript/new_design/champs/te_fenua.js
@@ -46,12 +46,9 @@ function initializeTeFenuaMap(container) {
 
 // Initialise la carte TeFenua quand le DOM est prêt
 async function initialize() {
-  const elements = document.querySelectorAll('.te-fenua:not([data-initialized])');
   initializeTeFenuaMap(document);
 
   window.viewOnMap = viewOnMap;
-
-  elements.forEach((element) => {})
 
   // delegate('change', '[data-te-fenua-place]', (event) => {
   //   let map = getMapFromAddress(event.target);


### PR DESCRIPTION
This pull request includes changes to improve the initialization and handling of the TeFenua map in the `app/javascript/new_design/champs/te_fenua.js` file. The most important changes include refactoring the map initialization function and adding a MutationObserver to handle dynamic DOM changes.

Handling dynamic DOM changes:

* [`app/javascript/new_design/champs/te_fenua.js`](diffhunk://#diff-19d14288e66b09ad96b67518ad95e23a6d8b1b5b1909df60536cd987400ed5b9R473-R501): Added a MutationObserver to listen for DOM changes and initialize new TeFenua map elements dynamically. This ensures that maps added to the DOM after the initial page load are properly initialized.