### PR TITLE
fix: change typo for IDT

### DIFF
--- a/doc/faqs/usager/erreur-siret-lors-depot-de-dossier.fr.md
+++ b/doc/faqs/usager/erreur-siret-lors-depot-de-dossier.fr.md
@@ -1,79 +1,41 @@
 ---
-title: "Erreur SIRET lors d’un dépôt de dossier"
+title: "Erreur numéro TAHITI lors d’un dépôt de dossier"
 category: usager
 subcategory: dossier_technical_issue
-slug: "erreur-siret-lors-d-un-depot-de-dossier"
+slug: "erreur-numero-tahiti-lors-d-un-depot-de-dossier"
 locale: "fr"
-keywords: "erreur SIRET, dépôt de dossier, numéro SIRET, identification entreprise, URSSAF, INSEE, entreprise.data.gouv.fr"
+keywords: "erreur numero TAHITI, dépôt de dossier, numéro TAHITI, identification entreprise, URSSAF, INSEE, https://www.ispf.pf/rte"
 ---
 
-# Erreur SIRET lors d’un dépôt de dossier sur %{application_name}
+# Erreur numéro TAHITI lors d’un dépôt de dossier sur %{application_name}
 
-Cet article s’adresse exclusivement aux utilisateurs de %{application_name},
-rencontrant un problème relatif à l’identification par numéro de SIRET lors d’un
-dépôt de dossiers.
+Cet article s’adresse exclusivement aux utilisateurs de %{application_name}, rencontrant un problème relatif à l’identification par numéro TAHITI lors d’un dépôt de dossiers.
 
-Si votre problème n’est pas relatif à l’utilisation de la plateforme
-%{application_name}, vous pouvez consulter la page suivante :
-[Service-public.fr pour signaler un problème](https://www.service-public.fr/professionnels-entreprises/vosdroits/R17969/signaler-un-probleme)
+Si votre problème n’est pas relatif à l’utilisation de la plateforme de %{application_name}, vous pouvez consulter la page suivante : Service-public.fr pour signaler un problème
 
-Si vous rencontrez le message « Erreur SIRET » lorsque vous identifiez votre
-entreprise ou association lors d’un nouveau dépôt de dossier, le problème peut
-se résoudre de trois manières :
+Si vous rencontrez le message « Erreur numéro TAHITI » lorsque vous identifiez votre entreprise ou association lors d’un nouveau dépôt de dossier, le problème peut se résoudre de trois manières :
 
-## Vérifiez que le numéro est bien le numéro SIRET
+## Vérifiez que le numéro est bien le numéro TAHITI
 
-Le numéro SIRET contient 14 chiffres, et il est facilement confondu avec le
-numéro SIREN, qui lui n’en contient que 9. Assurez-vous que le numéro que vous
-indiquez est bien le numéro SIRET.
+Le numéro TAHITI dans Mes-Démarches contient 9 chiffres et non 6: il correspond au numéro Tahiti à 6 chiffres + 3 chiffres pour désigner l'établissement référencé: par exemple 003970-001
 
-## Cas du SIRET transmis par l’URSSAF
+## Cas du numéro TAHITI transmis par l’ISPF
 
-Pour les jeunes structures, il est possible que l’URSSAF vous ait transmis un
-numéro de SIRET provisoire. Seuls les numéros de SIRET transmis par l’INSEE sont
-pris en compte sur notre site.
+Pour les jeunes structures, il est possible que l’ISPF ou la CCISM vous ait transmis un numéro TAHITI qui n'est pas encore transmis à Mes-Démarches.
+Attendez le lundi suivant pour réessayer votre numéro.
 
-## Vérifiez la validité de votre numéro SIRET
+## Vérifiez la validité de votre numéro TAHITI
 
-Il est possible que le SIRET de votre entreprise ou association ait changé (suite
-à un déménagement par exemple, qui entraîne la fermeture de l’ancien
-établissement et rend le numéro de SIRET invalide), et ne fonctionne donc plus.
+Il est possible que le numéro TAHITI de votre entreprise ou association ait changé (suite à un déménagement par exemple, qui entraîne la fermeture de l’ancien établissement et rend le numéro TAHITI invalide), et ne fonctionne donc plus.
 
-Pour vous assurer de la validité et du caractère public de votre SIRET, allez sur
-[entreprise.data.gouv.fr](https://entreprise.data.gouv.fr), rentrez votre numéro
-de SIRET dans le champ de recherche, et vérifiez si votre SIRET est encore valide
-ou non. S’il ne l’est plus, la page affichée vous indiquera alors le nouveau
-numéro de SIRET.
+Pour vous assurer de la validité et du caractère public de votre numéro TAHITI, allez sur [www.ispf.pf/rte](www.ispf.pf/rte), rentrez votre numéro TAHITI dans le champ de recherche, et vérifiez si votre numéro TAHITI est encore valide ou non. S’il ne l’est plus, la page affichée vous indiquera alors le nouveau numéro TAHITI.
 
-Après l’immatriculation de votre entreprise, il faut compter quelques jours avant
-que les informations relatives à celle-ci ne soient disponibles et récupérables
-depuis entreprise.data.gouv.fr.
+## Lorsque les informations numéro TAHITI sont temporairement indisponibles
 
-## Vérifiez que les informations concernant votre entreprise sont publiques
-
-Certaines entreprises demandent à ce que leurs informations ne soient pas
-accessibles dans la base publique des SIRET. Si c’est le cas, nous ne pouvons pas
-récupérer les informations associées.
-
-Pour vous assurer que les informations de votre entreprises ne sont pas privées,
-allez sur l’Annuaire des Entreprises, et rentrez votre numéro de SIRET dans le
-champ de recherche.
-
-## Lorsque les informations SIRET sont temporairement indisponibles
-
-Si vous voyez un message _« Désolé, la récupération des informations SIRET est
-temporairement indisponible. Veuillez réessayer dans quelques instants. »_, cela
-signifie que le service externe de l’INSEE qui donne les informations d’entreprise
-a une panne temporaire.
+Si vous voyez un message « Désolé, la récupération des numéro TAHITI est temporairement indisponible. Veuillez réessayer dans quelques instants. », cela signifie que le service externe de la Direction des Systèmes d'information du Pays qui donne les informations d’entreprise a une panne temporaire.
 
 La plupart du temps, le problème est résolu en quelques heures maximum.
 
-Pour plus d’information, vous pouvez consulter l’état du service SIRET. Si une des
-lignes est rouge, c’est probablement la cause du problème.
-
 ## Contactez-nous
 
-Il est également possible que notre prestataire technique qui nous permet de faire
-de l’identification via un numéro SIRET rencontre des problèmes techniques. Si
-votre numéro SIRET est valide et que vous rencontrez toujours la même erreur,
-contactez-nous par email.
+Il est également possible que notre prestataire technique qui nous permet de faire de l’identification via un numéro TAHITI rencontre des problèmes techniques. Si votre numéro TAHITI est valide et que vous rencontrez toujours la même erreur, contactez-nous par email.

--- a/doc/faqs/usager/je-ne-peux-pas-faire-une-demande-car-je-n-ai-pas-de-SIRET.fr.md
+++ b/doc/faqs/usager/je-ne-peux-pas-faire-une-demande-car-je-n-ai-pas-de-SIRET.fr.md
@@ -1,26 +1,25 @@
 ---
-title: "Je ne peux pas faire une demande car je n’ai pas de SIRET"
+title: "Je ne peux pas faire une demande car je n’ai pas de numéro TAHITI"
 category: usager
 subcategory: dossier_technical_issue
-slug: "je-ne-peux-pas-faire-une-demande-car-je-n-ai-pas-de-SIRET"
+slug: "je-ne-peux-pas-faire-une-demande-car-je-n-ai-pas-de-numero-tahiti"
 locale: "fr"
-keywords: "demande sans SIRET, service de l’État SIRET, association RNA, particulier procédure, INSEE SIRET"
+keywords: "demande sans numéro TAHITI, service de l’État numéro TAHITI, association RNA, particulier procédure, INSEE TAHITI"
 ---
 
-# Je ne peux pas faire une demande car je n’ai pas de SIRET
+# Je ne peux pas faire une demande car je n’ai pas de numéro TAHITI
 
-## Si vous êtes un service de l’État
+## Si vous êtes un service du Pays
 
-Vous avez normalement un numéro SIRET. Recherchez le nom de votre service sur l’[annuaire des entreprises](https://annuaire-entreprises.data.gouv.fr/),
-vous devriez alors le trouver ainsi que le numéro SIRET associé.
+Vous avez normalement un numéro TAHITI. Recherchez le nom de votre service sur l’[annuaire des entreprises](https://www.ispf.pf/rte), vous devriez alors le trouver ainsi que le numéro TAHITI associé.
 
 ## Si vous êtes une association
 
-Vous avez sans doute un numéro au Registre National des Associations, mais pas forcément de numéro SIRET.
-Il n’est pour l’instant malheureusement pas possible d’utiliser %{application_name} avec uniquement un numéro de RNA.
+Vous avez sans doute un numéro au Registre National des Associations, mais pas forcément de numéro TAHITI. Il n’est pour l’instant malheureusement pas possible d’utiliser %{application_name} avec uniquement un numéro de RNA.
 
-La demande d’un numéro de SIRET à l’INSEE peut se faire assez simplement par email, en envoyant un message à *sirene-associations@insee.fr*. La procédure est décrite en détail sur cette page, avec un exemple de message-type : [https://www.service-public.fr/associations/vosdroits/F1926](https://www.service-public.fr/associations/vosdroits/F1926)
+La demande d’un numéro de numéro TAHITI est décrite sur le site [https://www.polynesie-francaise.pref.gouv.fr/Demarches/Associations-et-Agrements/Inscription-au-repertoire-territorial-des-entreprises-R.T.E](https://www.polynesie-francaise.pref.gouv.fr/Demarches/Associations-et-Agrements/Inscription-au-repertoire-territorial-des-entreprises-R.T.E)
+ou vous pouvez aussi aller directement sur le site de la CCISM : [https://www.ccism.pf/la-ccism/vos-formalites](https://www.ccism.pf/la-ccism/vos-formalites)
 
 ## Si vous êtes un particulier
 
-Il est probable que la procédure sur laquelle vous voulez déposer une demande ne soit ouverte qu’aux entreprises. Si vous pensez que vous êtes bien la cible de cette procédure et que vous devriez pouvoir y déposer une demande, **contactez le service en charge de la démarche pour le signaler**.
+Vous devez alors ouvrir une patente auprès de la CCISM pour obtenir un numéro Tahiti : [https://www.ccism.pf/la-ccism/vos-formalites](https://www.ccism.pf/la-ccism/vos-formalites)


### PR DESCRIPTION
This pull request updates documentation to replace references to the French SIRET system with the Tahitian TAHITI system, reflecting a change in the identification process for businesses and organizations. The changes include updates to titles, keywords, and content across two FAQ articles.

### Updates to reflect the transition from SIRET to TAHITI:

* **File: `doc/faqs/usager/erreur-siret-lors-depot-de-dossier.fr.md`**
  - Replaced all mentions of "SIRET" with "numéro TAHITI" to align with the Tahitian identification system.
  - Updated examples, explanations, and links to reference the TAHITI system (e.g., ISPF and CCISM) instead of the French INSEE system.

* **File: `doc/faqs/usager/je-ne-peux-pas-faire-une-demande-car-je-n-ai-pas-de-SIRET.fr.md`**
  - Changed references from "SIRET" to "numéro TAHITI" and updated related processes for obtaining a TAHITI number, including links to ISPF and CCISM resources.
  - Adjusted sections for specific user groups (e.g., associations, individuals) to reflect Tahitian procedures.