### PR TITLE
feat: te_fenua improvements

### DIFF
--- a/app/assets/images/icons/geolocate.svg
+++ b/app/assets/images/icons/geolocate.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+ width="225.000000pt" height="225.000000pt" viewBox="0 0 225.000000 225.000000"
+ preserveAspectRatio="xMidYMid meet">
+
+<g transform="translate(0.000000,225.000000) scale(0.100000,-0.100000)"
+fill="#000000" stroke="none">
+<path d="M1970 2126 c-41 -18 -466 -216 -945 -440 -912 -426 -935 -438 -935
+-500 0 -31 34 -72 78 -95 21 -10 183 -67 362 -125 l325 -107 115 -341 c63
+-188 123 -355 135 -372 47 -69 104 -72 156 -6 25 32 860 1808 887 1889 28 80
+2 131 -65 131 -21 0 -72 -16 -113 -34z"/>
+</g>
+</svg>

--- a/app/assets/stylesheets/te_fenua.scss
+++ b/app/assets/stylesheets/te_fenua.scss
@@ -99,7 +99,7 @@
     bottom: auto;
     left: 2.8em;
     right: auto;
-    top: 6.1em;
+    top: 7.1em;
 
     &::after {
       border: 0.357em solid transparent;

--- a/app/assets/stylesheets/te_fenua.scss
+++ b/app/assets/stylesheets/te_fenua.scss
@@ -1,8 +1,8 @@
-// MES CONTRROLES
+// MES CONTROLES
 
 .ol-control-add {
   left: 0.5em;
-  top: 7em;
+  top: 8em;
 
   button {
     background-image: image-url("icons/polygon.svg");
@@ -12,7 +12,7 @@
 
 .ol-control-delete {
   left: 0.5em;
-  top: 9em;
+  top: 10em;
 
   button {
     background-image: image-url("icons/trash-gray.svg");
@@ -22,7 +22,7 @@
 
 .ol-control-layers {
   left: 0.5em;
-  top: 11em;
+  top: 6em;
 
   button {
     background-image: image-url("icons/layers.svg");
@@ -32,12 +32,12 @@
 
 .ol-control-geolocate {
   left: 0.5em;
-  top: 5em;
+  top: 4em;
 }
 
 .ol-control-geolocate button {
-  background-image: image-url("icons/marker.svg");
-  background-size: 18px;
+  background-image: image-url("icons/geolocate.svg");
+  background-size: 16px;
   background-repeat: no-repeat;
   background-position: center;
   cursor: pointer;

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -178,14 +178,14 @@
                           = t(".layers.#{name}")
           - if type_de_champ.te_fenua?
             .flex.width-33
-              .flex.flex-grow.align-center.fr-m-3v
-                .cell
-                  .carte-options
-                    = form.fields_for :editable_options do |form|
-                      - TypesDeChamp::TeFenuaTypeDeChamp::LAYERS.each do |layer|
-                        = form.label :te_fenua_layer, for: dom_id(type_de_champ, "layer_#{layer}") do
-                          = form.radio_button :te_fenua_layer, layer, checked: type_de_champ.options["te_fenua_layer"] == layer.to_s, class: 'small-margin small', id: dom_id(type_de_champ, "layer_#{layer}")
-                          = t(".layers.#{layer}")
+            .flex.column.width-33
+              .cell
+                .carte-options
+                  = form.fields_for :editable_options do |form|
+                    - TypesDeChamp::TeFenuaTypeDeChamp::LAYERS.each do |layer|
+                      = form.label :te_fenua_layer, for: dom_id(type_de_champ, "layer_#{layer}") do
+                        = form.radio_button :te_fenua_layer, layer, checked: type_de_champ.options["te_fenua_layer"] == layer.to_s, class: 'small-margin small', id: dom_id(type_de_champ, "layer_#{layer}")
+                        = t(".layers.#{layer}")
           - if type_de_champ.textarea?
             .cell
               = form.label :character_limit, for: dom_id(type_de_champ, :character_limit) do

--- a/app/javascript/new_design/champs/te_fenua.js
+++ b/app/javascript/new_design/champs/te_fenua.js
@@ -348,7 +348,7 @@ function addInteractions(mapElement, map) {
         (feature) => feature,
         {
           layerFilter: (layer) => layer === map.markerLayer,
-          hitTolerance: 8,
+          hitTolerance: 8
         }
       );
 

--- a/app/javascript/new_design/champs/te_fenua.js
+++ b/app/javascript/new_design/champs/te_fenua.js
@@ -266,6 +266,15 @@ function addInteractions(mapElement, map) {
   hideHelps();
   let draw, select, modify;
 
+  if (add_zone || add_marker) {
+    createControl(
+      map,
+      clickOnToggleCadastre,
+      'layers',
+      'Afficher/masquer le cadastre'
+    );
+  }
+
   if (add_zone) {
     bubbles.add.style.display = 'block';
     draw = new Draw({
@@ -280,12 +289,6 @@ function addInteractions(mapElement, map) {
     map.addInteraction(select);
     createControl(map, clickOnAddZone, 'add', 'Ajouter une zone');
     createControl(map, clickOnEffaceZone, 'delete', 'Effacer une zone');
-    createControl(
-      map,
-      clickOnToggleCadastre,
-      'layers',
-      'Afficher/masquer le cadastre'
-    );
     draw.on('drawend', (e) => {
       bubbles.add_zone.style.display = 'none';
       let source = map.zoneManuellesLayer.getSource();
@@ -344,7 +347,8 @@ function addInteractions(mapElement, map) {
         evt.pixel,
         (feature) => feature,
         {
-          layerFilter: (layer) => layer === map.markerLayer
+          layerFilter: (layer) => layer === map.markerLayer,
+          hitTolerance: 8,
         }
       );
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -171,7 +171,8 @@ class TypeDeChamp < ApplicationRecord
                  :collapsible_explanation_text,
                  :lexpol_modele,
                  :lexpol_mapping,
-                 :header_section_level
+                 :header_section_level,
+                 :te_fenua_layer
 
   has_many :revision_types_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', dependent: :destroy, inverse_of: :type_de_champ
   has_one :revision_type_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', inverse_of: false
@@ -197,6 +198,7 @@ class TypeDeChamp < ApplicationRecord
   serialize :condition, LogicSerializer
 
   after_initialize :set_dynamic_type
+  after_initialize :set_te_fenua_layer_default
   after_create :populate_stable_id
 
   attr_reader :dynamic_type
@@ -851,7 +853,13 @@ class TypeDeChamp < ApplicationRecord
     end
   end
 
-  private
+  def set_te_fenua_layer_default
+    if type_champ == 'te_fenua' && options['te_fenua_layer'].blank?
+      self.options['te_fenua_layer'] = 'marker'
+    end
+  end
+
+  private # TODO : Why 2 privates in this file ?
 
   DEFAULT_EMPTY = ['']
   def parse_drop_down_list_value(value)

--- a/app/models/types_de_champ/te_fenua_type_de_champ.rb
+++ b/app/models/types_de_champ/te_fenua_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::TeFenuaTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  LAYERS = [:parcelles, :zones_manuelles, :marker] # , :batiments
+  LAYERS = [:marker, :zones_manuelles] # :batiments, :parcelles
 
   class << self
     def champ_value_for_api(champ, version = 2)

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -157,9 +157,11 @@ describe 'As an administrateur I can edit types de champ', js: true do
 
     select('Carte de Polynésie', from: 'Type de champ')
     fill_in 'Libellé du champ', with: 'Libellé de champ Te Fenua', fill_options: { clear: :backspace }
-    choose 'Parcelles du cadastre'
+    # choose 'Parcelles du cadastre'
+    # choose 'Zones manuelles'
+    choose 'Marqueur'
 
-    wait_until { procedure.active_revision.types_de_champ_public.first.options["te_fenua_layer"] == 'parcelles' }
+    wait_until { procedure.active_revision.types_de_champ_public.first.options["te_fenua_layer"] == 'marker' }
     expect(page).to have_content('Formulaire enregistré')
 
     page.refresh

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -157,8 +157,6 @@ describe 'As an administrateur I can edit types de champ', js: true do
 
     select('Carte de Polynésie', from: 'Type de champ')
     fill_in 'Libellé du champ', with: 'Libellé de champ Te Fenua', fill_options: { clear: :backspace }
-    # choose 'Parcelles du cadastre'
-    # choose 'Zones manuelles'
     choose 'Marqueur'
 
     wait_until { procedure.active_revision.types_de_champ_public.first.options["te_fenua_layer"] == 'marker' }


### PR DESCRIPTION
![Capture d’écran 2025-06-04 à 15 12 01](https://github.com/user-attachments/assets/63cc8af9-06dd-486c-95aa-b5afae04c62a)

### Map UI and Styling Adjustments:
Updated control positions for better alignment and replaced the geolocate button icon and size for consistency.

### Map Functionality Enhancements:
Added a conditional control for toggling the cadastre visibility and adjusted the hit tolerance for marker layer interactions.

### Layer Default Handling:
Introduced a method `set_te_fenua_layer_default` to ensure the default layer is set to `marker` when no layer is specified for Te Fenua fields.

### Layer Option Refinement:
Update available layers by removing `parcelles` and retaining only `marker` and `zones_manuelles`.

### Test Updates:
Updated system tests to reflect the changes
