### PR TITLE
fix: fix the font size of the list items

### DIFF
--- a/app/assets/stylesheets/instructeur.scss
+++ b/app/assets/stylesheets/instructeur.scss
@@ -105,8 +105,7 @@
 
 .form {
   ul {
-    li
-     {
+    li {
       font-size: 14px;
     }
   }

--- a/app/assets/stylesheets/instructeur.scss
+++ b/app/assets/stylesheets/instructeur.scss
@@ -102,3 +102,12 @@
 .print-header {
   display: none;
 }
+
+.form {
+  ul {
+    li
+     {
+      font-size: 14px;
+    }
+  }
+}


### PR DESCRIPTION
Before, the font size of every items of the list were bigger than the description above:
<img width="347" height="127" alt="before" src="https://github.com/user-attachments/assets/0a7db3a8-26c2-4e59-8ac6-324e329902ce" />

And now, the font size of every items of the list is the same as the description above: 
<img width="256" height="103" alt="after" src="https://github.com/user-attachments/assets/157d4e70-9468-429d-bcbf-294a7f582b0a" />
