### PR TITLE
fix: remove useless description fields clone

### DIFF
--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
@@ -14,9 +14,6 @@
   %span.updated-at.highlighted
     = t('.check_content_rebased')
 
-- if @champ.description.present?
-  %span.fr-hint-text.champ-description= render SimpleFormatComponent.new(@champ.description, allow_a: true)
-
 - if hint?
   %span.fr-hint-text{ data: { controller: 'date-input-hint' } }= hint
 


### PR DESCRIPTION
Resolve [#194](https://github.com/govpf/mes-demarches/issues/194)

Pour le champ description, je suis allé vérifier sur le repo officiel, ils ont eux la description avec la font la plus petite que j'ai donc gardé. J'ai supprimé le doublon ajouté sur notre repo pour éviter une futur dette. A valider de ton côté car le ticket d'issue avait avancé l'autre solution. 

<img width="367" height="225" alt="Capture d’écran 2025-09-30 à 09 59 07" src="https://github.com/user-attachments/assets/05b021b1-ee33-4a82-8a7f-0fe3d26114c4" />

