### PR TITLE
Feat/duplicate champ

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -236,6 +236,7 @@
       = render TypesDeChampEditor::SelectChampPositionComponent.new(revision:, coordinate:)
 
       .flex.right
+        = render TypesDeChampEditor::DuplicateChampButtonComponent.new(coordinate: coordinate, after_stable_id: type_de_champ.stable_id)
         - if coordinate.used_by_routing_rules?
           %span
             utilisé pour
@@ -248,5 +249,6 @@
           = button_to type_de_champ_path, class: 'fr-btn fr-btn--tertiary-no-outline fr-icon-delete-line', title: "Supprimer le champ", method: :delete, form: { data: { turbo_confirm: 'Êtes vous sûr de vouloir supprimer ce champ ?' } } do
             %span.sr-only Supprimer
 
-  .type-de-champ-add-button{ class: class_names(root: !coordinate.child?, flex: true) }
-    = render TypesDeChampEditor::AddChampButtonComponent.new(revision: coordinate.revision, parent: coordinate&.parent, is_annotation: coordinate.private?, after_stable_id: type_de_champ.stable_id)
+  .type-de-champ-buttons.fr-mb-2w{ class: class_names(root: !coordinate.child?, flex: true) }
+    .type-de-champ-add-button
+      = render TypesDeChampEditor::AddChampButtonComponent.new(revision: coordinate.revision, parent: coordinate&.parent, is_annotation: coordinate.private?, after_stable_id: type_de_champ.stable_id)

--- a/app/components/types_de_champ_editor/duplicate_champ_button_component.rb
+++ b/app/components/types_de_champ_editor/duplicate_champ_button_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class TypesDeChampEditor::DuplicateChampButtonComponent < ApplicationComponent
+  def initialize(coordinate:, after_stable_id: nil)
+    @coordinate = coordinate
+    @after_stable_id = after_stable_id
+  end
+
+  private
+
+  def procedure
+    @coordinate.revision.procedure
+  end
+
+  def stable_id
+    @coordinate.stable_id
+  end
+
+  def button_options
+    {
+      class: "fr-btn fr-btn--tertiary-no-outline fr-icon-file-copy-line",
+      method: :post,
+      title: "Dupliquer le champ"
+    }
+  end
+end

--- a/app/components/types_de_champ_editor/duplicate_champ_button_component/duplicate_champ_button_component.html.haml
+++ b/app/components/types_de_champ_editor/duplicate_champ_button_component/duplicate_champ_button_component.html.haml
@@ -1,0 +1,2 @@
+= button_to(duplicate_admin_procedure_type_de_champ_path(procedure, stable_id), button_options) do
+  %span.sr-only Dupliquer

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -3,7 +3,7 @@
 module Administrateurs
   class TypesDeChampController < AdministrateurController
     before_action :retrieve_procedure
-    after_action :reset_procedure, only: [:create, :update, :destroy, :piece_justificative_template]
+    after_action :reset_procedure, only: [:create, :update, :destroy, :piece_justificative_template, :duplicate]
     before_action :reload_procedure_with_includes, only: [:destroy]
 
     def create
@@ -116,6 +116,33 @@ module Administrateurs
           @destroyed = @coordinate
           @morphed = champ_components_starting_at(@coordinate)
         end
+      end
+    end
+
+    def duplicate
+      default_type_de_champ = draft.find_and_ensure_exclusive_use(params[:stable_id])
+      @coordinate = draft.coordinate_for(default_type_de_champ)
+
+      new_champ_params = {
+        type_champ: default_type_de_champ.type_champ,
+        libelle: default_type_de_champ.libelle.to_s,
+        description: default_type_de_champ.description,
+        mandatory: default_type_de_champ.mandatory,
+        options: default_type_de_champ.options,
+        condition: default_type_de_champ.condition,
+        private: default_type_de_champ.private,
+        after_stable_id: @coordinate.stable_id
+      }
+
+      type_de_champ = draft.add_type_de_champ(new_champ_params)
+
+      if type_de_champ.valid?
+        @coordinate = draft.coordinate_for(type_de_champ)
+        ProcedureRevisionPreloader.load_one(@coordinate.revision)
+        @created = champ_component_from(@coordinate, focused: true)
+        @morphed = champ_components_starting_at(@coordinate, 1)
+      else
+        flash.alert = type_de_champ.errors.full_messages
       end
     end
 

--- a/app/views/administrateurs/types_de_champ/duplicate.turbo_stream.haml
+++ b/app/views/administrateurs/types_de_champ/duplicate.turbo_stream.haml
@@ -1,0 +1,1 @@
+= render partial: 'insert'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -756,6 +756,7 @@ Rails.application.routes.draw do
           patch :move_down
           put :piece_justificative_template
           put :notice_explicative
+          post :duplicate
         end
       end
 

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -246,4 +246,40 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       end
     end
   end
+
+  describe '#duplicate' do
+    let(:params) do
+      {
+        procedure_id: procedure.id,
+        stable_id: second_coordinate.stable_id
+      }
+    end
+
+    subject { post :duplicate, params: params, format: :turbo_stream }
+
+    context 'duplicate type_de_champ text' do
+      let(:type_champ) { TypeDeChamp.type_champs.fetch(:text) }
+
+      # l1, l2, l3 => l1, l2, l2, l3
+      # created: (l2, [l1, l2]), morphed: (l3, [l1, l2, l2])
+      it do
+        is_expected.to have_http_status(:ok)
+        expect(flash.alert).to eq(nil)
+        expect(extract_libelle(assigns(:created))).to eq(['l2', ['l1', 'l2']])
+        expect(morpheds).to eq([['l3', ['l1', 'l2', 'l2']]])
+      end
+    end
+
+    context 'duplicate with options' do
+      before do
+        second_coordinate.type_de_champ.update(options: { min: 10, max: 100 })
+      end
+
+      it 'copies the options' do
+        is_expected.to have_http_status(:ok)
+        created_champ = assigns(:created).coordinate.type_de_champ
+        expect(created_champ.options).to eq({ 'min' => 10, 'max' => 100 })
+      end
+    end
+  end
 end


### PR DESCRIPTION
**WIP**
_Ce qui est fait_ : 

- Les champs se dupliquent parfaitement bien en prenant en compte : le type de champ, le libellé et la description. Dans le doute j'y ai ajouté le `mandatory ` (pour savoir si un champ est obligatoire ou non), mais je ne suis vraiment pas sûre que cet attribut soit nécessaire dans la duplication.
- Un premier test confirmant que l'action `duplicate` est fonctionnelle.
- Proposition d'emplacement du bouton (cf capture d'écran)

<img width="2185" height="1440" alt="Capture d'écran 2025-10-01 160855" src="https://github.com/user-attachments/assets/b88bca9f-a238-4cd1-84b1-ff70b1cd4ebf" />

_Ce qui reste à faire_ : 
- Un rebase, pour nettoyer tous les commits "wip"
- Suppression des commentaires 
- Vérification des linters
- D'autres tests qui pourraient être utiles ?
- D'autres fonctionnalités liées à la duplication à mettre en place ?

J'oublie peut-être des choses dans ce qu'il me reste à faire, n'hésitez pas à me dire 
