### PR TITLE
fix: exclure les explications de l'export PDF du dossier

### DIFF
--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -159,7 +159,7 @@ def add_single_champ(pdf, champ)
   return if champ.conditional? && !champ.visible?
 
   case champ.type
-  when 'Champs::PieceJustificativeChamp', 'Champs::TitreIdentiteChamp'
+  when 'Champs::PieceJustificativeChamp', 'Champs::TitreIdentiteChamp', 'Champs::ExplicationChamp'
     return
   when 'Champs::HeaderSectionChamp'
     libelle = if @dossier.auto_numbering_section_headers_for?(tdc)
@@ -169,8 +169,6 @@ def add_single_champ(pdf, champ)
     end
 
     add_section_title(pdf, libelle)
-  when 'Champs::ExplicationChamp'
-    format_in_2_lines(pdf, tdc.libelle, strip_tags(tdc.description))
   when 'Champs::CarteChamp'
     pdf.pad_bottom(4) do
       pdf.font 'marianne', style: :bold, size: 12 do


### PR DESCRIPTION
### Description

Les champs d'explication ne doivent pas apparaître dans le PDF exporté car ils concernent uniquement le remplissage du formulaire en ligne et n'ont pas de pertinence dans le document final.

Cette correction ajoute `Champs::ExplicationChamp` à la liste des types de champs ignorés lors de la génération du PDF, aux côtés des pièces justificatives et des titres d'identité.

Fixes #211

---
Generated with [Claude Code](https://claude.ai/code)