### PR TITLE
fix: gérer les drop_down_options nil dans la comparaison de révisions

### DIFF
--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -48,8 +48,8 @@
         - list.with_item do
           = t(".#{prefix}.update_notice_explicative", label: change.label)
       - when :drop_down_options
-        - added = change.to.sort - change.from.sort
-        - removed = change.from.sort - change.to.sort
+        - added = (change.to || []).sort - (change.from || []).sort
+        - removed = (change.from || []).sort - (change.to || []).sort
         - list.with_item do
           = t(".#{prefix}.update_drop_down_options", label: change.label)
           = render Dsfr::ListComponent.new do |list|


### PR DESCRIPTION
## Contexte

Erreur en production lors de la consultation des changements d'une révision de procédure :
```
ActionView::Template::Error (undefined method `sort' for nil)
```

## Problème

Lorsqu'un administrateur passe un champ `drop_down_list` du mode **manuel** au mode **référentiel CSV** sans uploader de fichier, l'attribut `drop_down_options` est initialisé à `nil`.

L'algorithme de comparaison des révisions dans `RevisionChangesComponent` tentait d'appeler `.sort` sur cette valeur `nil` :

```ruby
- added = change.to.sort - change.from.sort      # ❌ crash si change.to est nil
- removed = change.from.sort - change.to.sort    # ❌ crash si change.from est nil
```

## Solution

Protection défensive : traiter `nil` comme une liste vide `[]` lors du calcul des différences :

```ruby
- added = (change.to || []).sort - (change.from || []).sort
- removed = (change.from || []).sort - (change.to || []).sort
```

## Périmètre

- ✅ Correction appliquée uniquement à `:drop_down_options` (lignes 51-52)
- ❌ Pas de modification pour `:carte_layers` et `:accredited_user_list` (retournent toujours `[]`)

## Tests

- Aucun test spécifique pour ce composant
- Fix défensif minimal, aucun risque de régression

---

**Priorité : HOTFIX** 🚨

Fixes procedure #1933

🤖 Generated with [Claude Code](https://claude.com/claude-code)