### PR TITLE
fix: normaliser la comparaison des drop_down_options pour les référentiels CSV

### DIFF
--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -418,11 +418,15 @@ class ProcedureRevision < ApplicationRecord
           from_type_de_champ.referentiel,
           to_type_de_champ.referentiel)
       end
-      if from_type_de_champ.drop_down_options != to_type_de_champ.drop_down_options
+      # pf: normaliser la comparaison des drop_down_options pour ignorer les IDs des référentiels
+      # Permet d'éviter de signaler des changements lors du passage Manuel → CSV avec les mêmes labels
+      from_labels = normalize_drop_down_labels(from_type_de_champ.drop_down_options)
+      to_labels = normalize_drop_down_labels(to_type_de_champ.drop_down_options)
+      if from_labels != to_labels
         changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
           :drop_down_options,
-          from_type_de_champ.drop_down_options,
-          to_type_de_champ.drop_down_options)
+          from_labels,
+          to_labels)
       end
       if to_type_de_champ.linked_drop_down_list?
         if from_type_de_champ.drop_down_secondary_libelle != to_type_de_champ.drop_down_secondary_libelle
@@ -504,6 +508,13 @@ class ProcedureRevision < ApplicationRecord
       ineligibilite_rules.errors(types_de_champ_for(scope: :public).to_a)
         .each { errors.add(:ineligibilite_rules, :invalid) }
     end
+  end
+
+  # pf: normalise les options drop_down pour comparer uniquement les labels
+  # Gère le cas où les options sont nil (référentiel sans CSV) ou des tuples [label, id]
+  def normalize_drop_down_labels(options)
+    return [] if options.nil?
+    options.map { |opt| opt.is_a?(Array) ? opt.first : opt }
   end
 
   def replace_type_de_champ_by_clone(coordinate)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -450,7 +450,8 @@ class TypeDeChamp < ApplicationRecord
   def drop_down_options(simple: false)
     return Array.wrap(super()) if simple
     if referentiel_mode?
-      return if referentiel.nil?
+      # pf: retourner [] au lieu de nil pour éviter les crashs lors de la comparaison de révisions
+      return [] if referentiel.nil?
       header = referentiel.headers.first.parameterize.underscore
       Array.wrap(referentiel.items.map { [_1.data.values.first[header], _1.id] })
     else

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -668,6 +668,39 @@ describe ProcedureRevision do
           ])
         end
       end
+
+      # pf: tests pour la normalisation des drop_down_options lors de la comparaison
+      context 'when switching from manual to referentiel mode with same labels' do
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'Commune', drop_down_options: ['Papeete', 'Faaa', 'Punaauia'] }]) }
+
+        before do
+          tdc = new_draft.types_de_champ_public.first
+          # Simuler le passage en mode référentiel avec les mêmes labels mais des IDs
+          allow(tdc).to receive(:drop_down_options).and_return([['Papeete', '1'], ['Faaa', '2'], ['Punaauia', '3']])
+        end
+
+        it 'does not report changes in drop_down_options when labels are identical' do
+          # La normalisation doit ignorer les IDs et ne détecter aucun changement
+          drop_down_changes = subject.filter { |change| change[:attribute] == :drop_down_options }
+          expect(drop_down_changes).to be_empty
+        end
+      end
+
+      context 'when drop_down_options changes from filled to empty' do
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'Liste', drop_down_options: ['A', 'B'] }]) }
+
+        before do
+          tdc = new_draft.find_and_ensure_exclusive_use(new_draft.types_de_champ_public.first.stable_id)
+          tdc.update(drop_down_options: [])
+        end
+
+        it 'reports removal of all options' do
+          drop_down_changes = subject.filter { |change| change[:attribute] == :drop_down_options }
+          expect(drop_down_changes).not_to be_empty
+          expect(drop_down_changes.first[:from]).to eq(['A', 'B'])
+          expect(drop_down_changes.first[:to]).to eq([])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Contexte

En production, deux problèmes liés aux drop_down en mode référentiel CSV :

1. **Crash lors de la comparaison** : `undefined method 'sort' for nil` (#213 - hotfix déjà appliqué sur masterpf)
2. **UX confuse** : Passage manuel → CSV avec mêmes labels affiche "Tout supprimé + Tout ajouté"

## Problèmes identifiés

### 1. `drop_down_options` retourne `nil`

**Fichier** : `app/models/type_de_champ.rb:453`

Quand le mode référentiel est activé mais aucun CSV uploadé :
```ruby
if referentiel_mode?
  return if referentiel.nil?  # ❌ retourne nil au lieu de []
```

**Impact** : Crash dans le template de comparaison (`.sort` sur nil)

### 2. Comparaison naïve des options

**Fichier** : `app/models/procedure_revision.rb:421-425`

Formats différents selon le mode :
- **Manuel** : `["Paris", "Lyon"]` (strings)
- **Référentiel** : `[["Paris", "id1"], ["Lyon", "id2"]]` (tuples)

**Impact** : Changement de mode détecté comme suppression totale + ajout total, même si les labels sont identiques

## Solutions implémentées

### 1. Retourner `[]` au lieu de `nil` (pf)

```ruby
# app/models/type_de_champ.rb:453
# pf: retourner [] au lieu de nil pour éviter les crashs lors de la comparaison de révisions
return [] if referentiel.nil?
```

### 2. Normaliser la comparaison (pf)

```ruby
# app/models/procedure_revision.rb:421-429
# pf: normaliser la comparaison des drop_down_options pour ignorer les IDs des référentiels
# Permet d'éviter de signaler des changements lors du passage Manuel → CSV avec les mêmes labels
from_labels = normalize_drop_down_labels(from_type_de_champ.drop_down_options)
to_labels = normalize_drop_down_labels(to_type_de_champ.drop_down_options)
if from_labels != to_labels
  changes << ProcedureRevisionChange::UpdateChamp.new(...)
end

# Méthode helper
def normalize_drop_down_labels(options)
  return [] if options.nil?
  options.map { |opt| opt.is_a?(Array) ? opt.first : opt }
end
```

**Résultat** :
- Manuel `["Paris", "Lyon"]` → Normalisé : `["Paris", "Lyon"]`
- Référentiel `[["Paris", "id1"], ["Lyon", "id2"]]` → Normalisé : `["Paris", "Lyon"]`
- Comparaison : **aucun changement détecté** ✅

## Tests ajoutés

### 1. Passage manuel → référentiel avec mêmes labels
```ruby
# spec/models/procedure_revision_spec.rb:673-687
context 'when switching from manual to referentiel mode with same labels' do
  # Vérifie qu'aucun changement n'est signalé
end
```

### 2. Changement réel d'options
```ruby
# spec/models/procedure_revision_spec.rb:689-703
context 'when drop_down_options changes from filled to empty' do
  # Vérifie que les vrais changements sont bien détectés
end
```

**Résultats** : ✅ 74 examples, 0 failures

## Tags PF

Toutes les modifications sont marquées `# pf:` pour identifier ces spécificités Polynésie liées au système de référentiels CSV.

## Relation avec #213

Cette PR complète le hotfix #213 (qui a blindé le template avec `|| []`). Ici on corrige la cause racine :
- ✅ Plus de `nil` retourné
- ✅ Comparaison intelligente qui ignore les IDs

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)