### PR TITLE
feat: Ajouter le format liste HTML pour les champs MultipleDropDownList dans Lexpol

### DIFF
--- a/app/services/lexpol_fields_service.rb
+++ b/app/services/lexpol_fields_service.rb
@@ -58,7 +58,8 @@ module LexpolFieldsService
     list_items = options.each_with_index.map do |opt, index|
       # Dernier élément se termine par '.', les autres par ' ;'
       punctuation = (index == options.size - 1) ? '.' : ' ;'
-      "<li>#{opt}#{punctuation}</li>"
+      escaped_opt = ERB::Util.html_escape(opt.to_s)
+      "<li>#{escaped_opt}#{punctuation}</li>"
     end
 
     "<ul>#{list_items.join}</ul>"

--- a/app/services/lexpol_fields_service.rb
+++ b/app/services/lexpol_fields_service.rb
@@ -52,6 +52,18 @@ module LexpolFieldsService
     end
   end
 
+  def self.format_as_html_list(options)
+    return '' if options.blank?
+
+    list_items = options.each_with_index.map do |opt, index|
+      # Dernier élément se termine par '.', les autres par ' ;'
+      punctuation = (index == options.size - 1) ? '.' : ' ;'
+      "<li>#{opt}#{punctuation}</li>"
+    end
+
+    "<ul>#{list_items.join}</ul>"
+  end
+
   def self.format_date(date)
     return '' if date.blank?
     begin

--- a/app/services/lexpol_service.rb
+++ b/app/services/lexpol_service.rb
@@ -61,7 +61,15 @@ class LexpolService
 
   def build_variables
     variables = dossier.champs.filter { |c| !c.child? }.reduce({}) do |variables, champ|
-      variables[champ.libelle] = LexpolFieldsService.format_lexpol_value(champ) if champ.present?
+      if champ.present?
+        # Variable standard
+        variables[champ.libelle] = LexpolFieldsService.format_lexpol_value(champ)
+
+        # Variable avec format liste pour MultipleDropDownListChamp
+        if champ.is_a?(Champs::MultipleDropDownListChamp)
+          variables["#{champ.libelle} (liste)"] = LexpolFieldsService.format_as_html_list(champ.selected_options)
+        end
+      end
       variables
     end
     LexpolService.default_mapping(champ.type_de_champ, dossier.procedure).reduce(variables) do |variables, (source_field, target_field)|
@@ -87,7 +95,14 @@ class LexpolService
 
   def self.lexpol_variables(lexpol_type_de_champ, procedure)
     default_variables = default_mapping(lexpol_type_de_champ, procedure).values
-    champ_variables = procedure.draft_revision.types_de_champ.map(&:libelle)
+
+    champ_variables = procedure.draft_revision.types_de_champ.flat_map do |tdc|
+      base = [tdc.libelle]
+      # Ajouter la version (liste) pour les champs à choix multiples
+      base << "#{tdc.libelle} (liste)" if tdc.type_champ == 'multiple_drop_down_list'
+      base
+    end
+
     (default_variables + champ_variables).sort_by(&:downcase)
   end
 

--- a/spec/services/lexpol_fields_service_spec.rb
+++ b/spec/services/lexpol_fields_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe LexpolFieldsService do
+  describe '.format_as_html_list' do
+    it 'formate une liste avec ponctuation Lexpol' do
+      options = ['A', 'B', 'C']
+      result = LexpolFieldsService.format_as_html_list(options)
+      expect(result).to eq('<ul><li>A ;</li><li>B ;</li><li>C.</li></ul>')
+    end
+
+    it 'retourne une chaîne vide si options vide' do
+      expect(LexpolFieldsService.format_as_html_list([])).to eq('')
+    end
+
+    it 'retourne une chaîne vide si options nil' do
+      expect(LexpolFieldsService.format_as_html_list(nil)).to eq('')
+    end
+
+    it 'gère un seul élément avec un point final' do
+      result = LexpolFieldsService.format_as_html_list(['Seul'])
+      expect(result).to eq('<ul><li>Seul.</li></ul>')
+    end
+
+    it 'gère deux éléments correctement' do
+      result = LexpolFieldsService.format_as_html_list(['Premier', 'Dernier'])
+      expect(result).to eq('<ul><li>Premier ;</li><li>Dernier.</li></ul>')
+    end
+  end
+end

--- a/spec/services/lexpol_fields_service_spec.rb
+++ b/spec/services/lexpol_fields_service_spec.rb
@@ -25,5 +25,19 @@ describe LexpolFieldsService do
       result = LexpolFieldsService.format_as_html_list(['Premier', 'Dernier'])
       expect(result).to eq('<ul><li>Premier ;</li><li>Dernier.</li></ul>')
     end
+
+    it 'échappe les caractères HTML dangereux' do
+      options = ['Option <script>alert("XSS")</script>', 'A & B', '"Quotes"', "L'apostrophe"]
+      result = LexpolFieldsService.format_as_html_list(options)
+
+      # Vérifie que les caractères dangereux sont échappés
+      expect(result).not_to include('<script>')
+      expect(result).to include('&lt;script&gt;')
+      expect(result).to include('&amp;')
+      expect(result).to include('&quot;')
+
+      # Vérifie la structure complète
+      expect(result).to eq('<ul><li>Option &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; ;</li><li>A &amp; B ;</li><li>&quot;Quotes&quot; ;</li><li>L&#39;apostrophe.</li></ul>')
+    end
   end
 end

--- a/spec/services/lexpol_service_spec.rb
+++ b/spec/services/lexpol_service_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe LexpolService do
+  let(:procedure) { create(:procedure, :published, :for_individual) }
+  let!(:lexpol_type_de_champ) { create(:type_de_champ_lexpol, procedure: procedure) }
+  let(:dossier) { create(:dossier, procedure: procedure) }
+  let(:lexpol_champ) { dossier.champs.find { |c| c.type_de_champ == lexpol_type_de_champ } }
+  let(:apilexpol) { instance_double(APILexpol) }
+  let(:service) { described_class.new(champ: lexpol_champ, dossier: dossier, apilexpol: apilexpol) }
+
+  describe '#build_variables' do
+    context 'avec un champ MultipleDropDownListChamp' do
+      let(:multiple_drop_down_tdc) do
+        create(:type_de_champ_multiple_drop_down_list,
+               libelle: 'Catégories',
+               drop_down_options: ['Option A', 'Option B', 'Option C'],
+               procedure: procedure)
+      end
+
+      before do
+        procedure.draft_revision.add_type_de_champ(multiple_drop_down_tdc)
+        dossier.reload
+      end
+
+      context 'avec des valeurs sélectionnées' do
+        let(:champ) do
+          dossier.champs.find { |c| c.type_de_champ == multiple_drop_down_tdc }
+        end
+
+        before do
+          champ.value = '["Option A","Option B","Option C"]'
+          champ.save!
+        end
+
+        it 'génère la variable standard' do
+          variables = service.build_variables
+          expect(variables['Catégories']).to eq('Option A, Option B et Option C')
+        end
+
+        it 'génère la variable avec suffixe (liste)' do
+          variables = service.build_variables
+          expect(variables['Catégories (liste)']).to eq('<ul><li>Option A ;</li><li>Option B ;</li><li>Option C.</li></ul>')
+        end
+      end
+
+      context 'avec un champ vide' do
+        let(:champ) do
+          dossier.champs.find { |c| c.type_de_champ == multiple_drop_down_tdc }
+        end
+
+        before do
+          champ.value = '[]'
+          champ.save!
+        end
+
+        it 'génère la variable standard vide' do
+          variables = service.build_variables
+          expect(variables['Catégories']).to eq('')
+        end
+
+        it 'génère la variable (liste) vide' do
+          variables = service.build_variables
+          expect(variables['Catégories (liste)']).to eq('')
+        end
+      end
+    end
+  end
+
+  describe '.lexpol_variables' do
+    let(:draft_procedure) { create(:procedure, :for_individual) }
+    let!(:draft_lexpol_tdc) { create(:type_de_champ_lexpol, procedure: draft_procedure) }
+
+    context 'avec un champ MultipleDropDownListChamp' do
+      let!(:multiple_drop_down_tdc) do
+        create(:type_de_champ_multiple_drop_down_list,
+               libelle: 'Catégories',
+               drop_down_options: ['Option A', 'Option B'],
+               procedure: draft_procedure)
+      end
+
+      it 'inclut la variable standard' do
+        variables = described_class.lexpol_variables(draft_lexpol_tdc, draft_procedure)
+        expect(variables).to include('Catégories')
+      end
+
+      it 'inclut la variable avec suffixe (liste)' do
+        variables = described_class.lexpol_variables(draft_lexpol_tdc, draft_procedure)
+        expect(variables).to include('Catégories (liste)')
+      end
+    end
+
+    context 'avec un champ non-multiple' do
+      let!(:text_tdc) do
+        create(:type_de_champ_text,
+               libelle: 'Nom',
+               procedure: draft_procedure)
+      end
+
+      it 'inclut uniquement la variable standard' do
+        variables = described_class.lexpol_variables(draft_lexpol_tdc, draft_procedure)
+        expect(variables).to include('Nom')
+        expect(variables).not_to include('Nom (liste)')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pour chaque champ de type MultipleDropDownListChamp, génère deux variables dans Lexpol :
- Variable standard : format texte actuel ("a, b et c")
- Variable avec suffixe (liste) : format liste HTML avec ponctuation Lexpol

La liste HTML respecte les conventions Lexpol :
- Chaque élément (sauf le dernier) se termine par ' ;'
- Le dernier élément se termine par '.'

✅ **Gestion des valeurs vides** : Si le champ est vide, la variable (liste) retourne une chaîne vide, garantissant que Lexpol n'utilisera pas de valeur par défaut.

Exemple : `<ul><li>Option A ;</li><li>Option B ;</li><li>Option C.</li></ul>`

Fixes #216

Generated with [Claude Code](https://claude.ai/code)