### PR TITLE
fix(lexpol): ajouter parenthèses autour des suffixes de champs liés

### DIFF
--- a/app/javascript/controllers/lexpol_preview_controller.ts
+++ b/app/javascript/controllers/lexpol_preview_controller.ts
@@ -78,7 +78,7 @@ export class LexpolPreviewController extends ApplicationController {
     Object.keys(allVars).forEach((key) => {
       let grouped = false;
       for (const suffix of suffixes) {
-        if (key.endsWith(` ${suffix}`)) {
+        if (key.endsWith(` (${suffix})`)) {
           if (!groups[suffix]) groups[suffix] = [];
           groups[suffix].push(key);
           grouped = true;

--- a/app/services/linked_dossier_fields_service.rb
+++ b/app/services/linked_dossier_fields_service.rb
@@ -144,7 +144,7 @@ class LinkedDossierFieldsService
 
   def merge_with_suffix(enriched, linked_variables, suffix)
     linked_variables.each do |field_name, value|
-      suffixed_name = "#{field_name} #{suffix}"
+      suffixed_name = "#{field_name} (#{suffix})"
       enriched[suffixed_name] = value
     end
   end

--- a/spec/services/linked_dossier_fields_service_spec.rb
+++ b/spec/services/linked_dossier_fields_service_spec.rb
@@ -41,16 +41,16 @@ describe LinkedDossierFieldsService do
         result = service.enrich_variables(base_variables)
 
         expect(result['Nom']).to eq('Carlsen')
-        expect(result['Prénom candidature']).to eq('Magnus')
-        expect(result['Numéro du dossier candidature']).to eq(linked_dossier.id.to_s)
+        expect(result['Prénom (candidature)']).to eq('Magnus')
+        expect(result['Numéro du dossier (candidature)']).to eq(linked_dossier.id.to_s)
       end
 
       it 'utilise le dernier mot significatif comme suffixe' do
         base_variables = {}
         result = service.enrich_variables(base_variables)
 
-        expect(result.keys).to include('Prénom candidature')
-        expect(result.keys).to include('Numéro du dossier candidature')
+        expect(result.keys).to include('Prénom (candidature)')
+        expect(result.keys).to include('Numéro du dossier (candidature)')
       end
 
       it 'ne suit pas récursivement les liens vers dossiers' do
@@ -74,7 +74,7 @@ describe LinkedDossierFieldsService do
         result = service.enrich_variables(base_variables)
 
         # On doit avoir les champs du 3ème dossier
-        expect(result['Ville candidature']).to eq('Amiens')
+        expect(result['Ville (candidature)']).to eq('Amiens')
         # Mais pas ceux du dossier lié au 3ème (pas de récursion)
         expect(result.keys.filter { |k| k.include?('Prénom') }).to be_empty
       end
@@ -96,9 +96,9 @@ describe LinkedDossierFieldsService do
         result = service.enrich_variables({})
 
         # Vérifier qu'on a bien les données niveau 1
-        expect(result['Info candidature']).to eq('Donnée niveau 1')
+        expect(result['Info (candidature)']).to eq('Donnée niveau 1')
         # Mais pas le champ DossierLink lui-même
-        expect(result.keys).not_to include('Dossier imbriqué candidature')
+        expect(result.keys).not_to include('Dossier imbriqué (candidature)')
         # Et surtout pas de récursion vers le dossier 999
         expect(result.keys.count).to be <= 10 # Pas d'explosion de variables
       end
@@ -129,9 +129,9 @@ describe LinkedDossierFieldsService do
         base_variables = {}
         result = service.enrich_variables(base_variables)
 
-        expect(result['Prénom candidature']).to eq('Magnus')
+        expect(result['Prénom (candidature)']).to eq('Magnus')
 
-        expect(result['Année annuel']).to eq('2024')
+        expect(result['Année (annuel)']).to eq('2024')
       end
     end
   end


### PR DESCRIPTION
## Description

Les variables envoyées à Lexpol pour les champs des dossiers liés utilisent maintenant des parenthèses autour du suffixe pour améliorer la lisibilité et éviter les ambiguïtés.

### Exemple

**Avant** : `Date de dépôt candidature`  
**Après** : `Date de dépôt (candidature)`

## Modifications

- **LinkedDossierFieldsService** : ajout de parenthèses dans `merge_with_suffix`
- **LexpolPreviewController** : mise à jour de la détection du suffixe pour le groupement des variables
- **Tests** : mise à jour de toutes les assertions pour refléter le nouveau format

## Tests

- ✅ Tests LinkedDossierFieldsService : 22 examples, 0 failures
- ✅ Tests LexpolService : 7 examples, 0 failures
- ✅ Rubocop : 2850 files, no offenses
- ✅ Haml-lint : 789 files, 0 lints

## Impact

Cette modification améliore la clarté des noms de variables envoyées à Lexpol, en particulier pour les champs ayant des noms composés. Les parenthèses permettent de distinguer clairement le nom du champ du suffixe identifiant le dossier lié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)