### PR TITLE
 feat: display conditional fields in emails

### DIFF
--- a/app/components/tags_button_list_component/tags_button_list_component.html.haml
+++ b/app/components/tags_button_list_component/tags_button_list_component.html.haml
@@ -17,6 +17,3 @@
         - label = button_label(tag)
         %button.fr-tag.fr-tag--sm{ type: "button", title: button_title(tag), data: { action: 'click->tiptap#insertTag', tiptap_target: 'tag', tag_id: tag[:id], tag_label: label } }
           = label
-        - if tag[:conditional]
-          %span.fr-badge.fr-badge--sm.fr-badge--info.fr-ml-1w
-            Champ conditionnel

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -371,18 +371,20 @@ module TagsSubstitutionConcern
 
   def champ_public_tags(dossier: nil)
     types_de_champ = (dossier || procedure.active_revision).types_de_champ_public
-    types_de_champ_tags(types_de_champ, Dossier::SOUMIS)
+    types_de_champ_tags(types_de_champ, Dossier::SOUMIS, dossier: dossier)
   end
 
   def champ_private_tags(dossier: nil)
     types_de_champ = (dossier || procedure.active_revision).types_de_champ_private
-    types_de_champ_tags(types_de_champ, Dossier::INSTRUCTION_COMMENCEE)
+    types_de_champ_tags(types_de_champ, Dossier::INSTRUCTION_COMMENCEE, dossier: dossier)
   end
 
   def types_de_champ_tags(types_de_champ, available_for_states, dossier: nil)
+    revision = dossier&.revision || procedure.active_revision
     tags = types_de_champ.flat_map do |tdc|
+      revision_tdc = revision.revision_types_de_champ.find { |rtdc| rtdc.type_de_champ_id == tdc.id }
       tdc.tags_for_template.map do |tag|
-        tag.merge(conditional: tdc.condition?, stable_id: tdc.stable_id)
+        tag.merge(conditional: tdc.condition?, stable_id: tdc.stable_id, order: revision_tdc&.position)
       end
     end
     tags.each do |tag|
@@ -458,15 +460,7 @@ module TagsSubstitutionConcern
   def parse_tags(text, dossier: nil)
     all_tags = procedure_types_de_champ_tags(dossier: dossier)
 
-    # Group tags by libelle to handle duplicates (such as multiple fields with the same name)
-    # Sort by stable_id in descending order to match visual order in templates
-    tags_by_libelle = all_tags.group_by { _1[:libelle] }.transform_values do |tag_list|
-      if tag_list.all? { |tag| tag[:stable_id].present? }
-        tag_list.sort_by { |tag| -tag[:stable_id] }
-      else
-        tag_list
-      end
-    end
+    tags_by_libelle = all_tags.group_by { _1[:libelle] }
 
     # MD5 should be enough and it avoids long key
     tokens = Rails.cache.fetch(["parse_tags_v2", Digest::MD5.hexdigest(text)], expires_in: 1.day) { TagsParser.parse(text) }
@@ -488,7 +482,8 @@ module TagsSubstitutionConcern
           tag: tag,
           id: tag_info.fetch(:id),
           conditional: tag_info[:conditional],
-          stable_id: tag_info[:stable_id]
+          stable_id: tag_info[:stable_id],
+          order: tag_info[:order]
         }
       else
         token

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -379,10 +379,10 @@ module TagsSubstitutionConcern
     types_de_champ_tags(types_de_champ, Dossier::INSTRUCTION_COMMENCEE)
   end
 
-  def types_de_champ_tags(types_de_champ, available_for_states)
+  def types_de_champ_tags(types_de_champ, available_for_states, dossier: nil)
     tags = types_de_champ.flat_map do |tdc|
       tdc.tags_for_template.map do |tag|
-        tag.merge(conditional: tdc.condition?)
+        tag.merge(conditional: tdc.condition?, stable_id: tdc.stable_id)
       end
     end
     tags.each do |tag|
@@ -398,7 +398,7 @@ module TagsSubstitutionConcern
 
     @escape_unsafe_tags = escape
 
-    tokens = parse_tags(text)
+    tokens = parse_tags(text, dossier: dossier)
 
     tags_and_datas = available_tags(dossier).filter_map do |tags|
       dossier && [tags_for_dossier_state(tags).index_by { _1[:id] }, dossier]
@@ -417,14 +417,22 @@ module TagsSubstitutionConcern
         end
       end
     end.map do |token|
-      # Get tokens text representation
-      case token
-      in { tag: tag }
-        "--#{tag}--"
-      in { text: text }
-        text
-      end
-    end.join('')
+        # Check if champ is conditional and visible
+        case token
+        in { tag: _, id: _id, conditional: true, stable_id: stable_id } if dossier
+          champ = dossier.champs.find { |c| c.stable_id == stable_id }
+          if champ&.visible?
+            "--#{token[:tag]}--"
+          else
+            ''
+          end
+        # Get tokens text representation
+        in { tag: tag }
+          "--#{tag}--"
+        in { text: text }
+          text
+        end
+      end.join('')
   end
 
   def replace_tag(tag, dossier)
@@ -441,21 +449,47 @@ module TagsSubstitutionConcern
     @escape_unsafe_tags
   end
 
-  def procedure_types_de_champ_tags
-    tags_for_dossier_state(types_de_champ_tags(procedure.types_de_champ_public_for_tags, Dossier::SOUMIS) +
-      types_de_champ_tags(procedure.types_de_champ_private_for_tags, Dossier::INSTRUCTION_COMMENCEE) +
+  def procedure_types_de_champ_tags(dossier: nil)
+    tags_for_dossier_state(types_de_champ_tags(procedure.types_de_champ_public_for_tags, Dossier::SOUMIS, dossier: dossier) +
+      types_de_champ_tags(procedure.types_de_champ_private_for_tags, Dossier::INSTRUCTION_COMMENCEE, dossier: dossier) +
       identity_tags + dossier_tags + ROUTAGE_TAGS)
   end
 
-  def parse_tags(text)
-    tags = procedure_types_de_champ_tags.index_by { _1[:libelle] }
+  def parse_tags(text, dossier: nil)
+    all_tags = procedure_types_de_champ_tags(dossier: dossier)
+
+    # Group tags by libelle to handle duplicates (such as multiple fields with the same name)
+    # Sort by stable_id in descending order to match visual order in templates
+    tags_by_libelle = all_tags.group_by { _1[:libelle] }.transform_values do |tag_list|
+      if tag_list.all? { |tag| tag[:stable_id].present? }
+        tag_list.sort_by { |tag| -tag[:stable_id] }
+      else
+        tag_list
+      end
+    end
 
     # MD5 should be enough and it avoids long key
     tokens = Rails.cache.fetch(["parse_tags_v2", Digest::MD5.hexdigest(text)], expires_in: 1.day) { TagsParser.parse(text) }
+
+    # Count how many times we've seen each tag libelle to handle duplicates
+    libelle_count = Hash.new(0)
+
     tokens.map do |token|
       case token
-      in { tag: tag } if tags.key?(tag)
-        { tag: tag, id: tags.fetch(tag).fetch(:id) }
+      in { tag: tag } if tags_by_libelle.key?(tag)
+        # Use counter to get the correct tag in case of duplicates
+        # The first tag uses index 0, the second index 1, etc.
+        index = libelle_count[tag]
+        libelle_count[tag] += 1
+
+        available_tags = tags_by_libelle[tag]
+        tag_info = available_tags[index] || available_tags.last
+        {
+          tag: tag,
+          id: tag_info.fetch(:id),
+          conditional: tag_info[:conditional],
+          stable_id: tag_info[:stable_id]
+        }
       else
         token
       end

--- a/app/views/administrateurs/mail_templates/_form.html.haml
+++ b/app/views/administrateurs/mail_templates/_form.html.haml
@@ -7,9 +7,10 @@
   %h2.fr-h3
     Insérer une balise
 
-  = render Dsfr::AlertComponent.new(state: :info, title: "Balises sur le conditionnel", heading_level: 'h3') do |c|
-    - c.with_body do
-      Les balises pour les champs conditionnés ne sont pour le moment pas supportées.
+  -# pf # 243 - Support des balises conditionnelles dans les emails
+  -# = render Dsfr::AlertComponent.new(state: :info, title: "Balises sur le conditionnel", heading_level: 'h3') do |c|
+  -#   - c.with_body do
+  -#     Les balises pour les champs conditionnés ne sont pour le moment pas supportées.
 
   %p.notice.fr-mt-3w
     Copiez-collez les balises ci-dessous pour afficher automatiquement l’information souhaitée.

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -708,4 +708,180 @@ describe TagsSubstitutionConcern, type: :model do
       ])
     end
   end
+
+  describe 'replace_tags with conditional fields' do
+    include Logic
+
+    let(:for_individual) { false }
+    let(:etablissement) { create(:etablissement) }
+    let(:state) { Dossier.states.fetch(:accepte) }
+
+    context 'when procedure has conditional fields with same libelle' do
+      let(:types_de_champ_public) do
+        [
+          {
+            type: :drop_down_list,
+            libelle: 'Commune',
+            drop_down_options: ['Papeete (98714)', 'Faaa (98704)', 'Punaauia (98717)']
+          },
+          { type: :text, libelle: 'Montant subvention' },
+          { type: :text, libelle: 'Montant subvention' }
+        ]
+      end
+
+      let!(:procedure_instance) { procedure }
+      let!(:dossier) { create(:dossier, :en_construction, procedure: procedure_instance, etablissement: etablissement) }
+      let!(:commune_tdc) { procedure_instance.draft_revision.types_de_champ.find { |tdc| tdc.libelle == 'Commune' } }
+      let!(:montant_papeete_tdc) { procedure_instance.draft_revision.types_de_champ.find { |tdc| tdc.libelle == 'Montant subvention' } }
+      let!(:montant_faaa_tdc) { procedure_instance.draft_revision.types_de_champ.filter { |tdc| tdc.libelle == 'Montant subvention' }[1] }
+
+      before do
+        montant_papeete_tdc.update!(condition: ds_eq(champ_value(commune_tdc.stable_id), constant('Papeete (98714)')))
+        montant_faaa_tdc.update!(condition: ds_eq(champ_value(commune_tdc.stable_id), constant('Faaa (98704)')))
+        dossier.reload
+      end
+
+      let(:commune_champ) { dossier.project_champs_public.find { |c| c.libelle == 'Commune' } }
+      let(:montant_papeete) { dossier.project_champs_public.find { |c| c.stable_id == montant_papeete_tdc.stable_id } }
+      let(:montant_faaa) { dossier.project_champs_public.find { |c| c.stable_id == montant_faaa_tdc.stable_id } }
+
+      context '1. champ conditionnel visible → balise substituée' do
+        let(:template) { 'Commune : --Commune--, Montant : --Montant subvention--' }
+
+        before do
+          commune_champ.update(value: 'Papeete (98714)')
+          montant_papeete.update(value: '500000')
+        end
+
+        subject { template_concern.send(:replace_tags, template, dossier) }
+
+        it 'remplace la valeur du champ visible' do
+          expect(subject).to eq('Commune : Papeete (98714), Montant : 500000')
+        end
+      end
+
+      context '2. champ conditionnel non rempli → string vide' do
+        let(:template) { 'Montant Papeete: --Montant subvention--, Montant Faaa: --Montant subvention--' }
+
+        before do
+          commune_champ.update(value: 'Papeete (98714)')
+          montant_papeete.update(value: '500000')
+        end
+
+        subject { template_concern.send(:replace_tags, template, dossier) }
+
+        it 'remplace le champ non rempli par une string vide' do
+          expect(subject).to eq('Montant Papeete: 500000, Montant Faaa: ')
+        end
+      end
+    end
+
+    context 'when dossier is nil with conditional fields' do
+      let(:types_de_champ_public) do
+        [
+          { type: :text, libelle: 'Montant subvention' },
+          { type: :text, libelle: 'Montant subvention' }
+        ]
+      end
+
+      context '3. dossier nil avec balise conditionnelle' do
+        let(:template) { 'Montant : --Montant subvention--' }
+        let(:dossier) { nil }
+
+        subject { template_concern.send(:replace_tags, template, dossier) }
+
+        it 'garde les balises intactes quand aucun dossier n\'est fourni' do
+          expect(subject).to eq('Montant : --Montant subvention--')
+        end
+      end
+    end
+
+    context '4. plusieurs champs conditionnels avec même libellé (archipels)' do
+  let(:types_de_champ_public) do
+    [
+      {
+        type: :drop_down_list,
+        libelle: 'Archipel',
+        drop_down_options: ['Iles du Vent', 'Iles Sous-le-Vent', 'Marquises']
+      },
+      { type: :text, libelle: 'Responsable' },
+      { type: :text, libelle: 'Responsable' }
+    ]
+  end
+
+  let!(:procedure_instance) { procedure }
+  let!(:dossier) { create(:dossier, :en_construction, procedure: procedure_instance, etablissement: etablissement) }
+  let!(:archipel_tdc) { procedure_instance.draft_revision.types_de_champ.find { |tdc| tdc.libelle == 'Archipel' } }
+  let!(:resp_idv_tdc) { procedure_instance.draft_revision.types_de_champ.find { |tdc| tdc.libelle == 'Responsable' } }
+  let!(:resp_islv_tdc) { procedure_instance.draft_revision.types_de_champ.filter { |tdc| tdc.libelle == 'Responsable' }[1] }
+
+  before do
+    resp_idv_tdc.update!(condition: ds_eq(champ_value(archipel_tdc.stable_id), constant('Iles du Vent')))
+    resp_islv_tdc.update!(condition: ds_eq(champ_value(archipel_tdc.stable_id), constant('Iles Sous-le-Vent')))
+    dossier.reload
+  end
+
+  let(:archipel_champ) { dossier.project_champs_public.find { |c| c.libelle == 'Archipel' } }
+  let(:resp_idv) { dossier.project_champs_public.find { |c| c.stable_id == resp_idv_tdc.stable_id } }
+  let(:template) { 'IDV: --Responsable--, ISLV: --Responsable--' }
+
+  before do
+    archipel_champ.update(value: 'Iles du Vent')
+    resp_idv.update(value: 'Jean Dupont')
+  end
+
+  subject { template_concern.send(:replace_tags, template, dossier) }
+
+  it 'affiche uniquement le champ conditionnel visible' do
+    expect(subject).to eq('IDV: Jean Dupont, ISLV: ')
+  end
+end
+
+    context 'when procedure has mix of normal and conditional fields' do
+      let(:types_de_champ_public) do
+        [
+          { type: :text, libelle: 'Nom du projet' },
+          {
+            type: :drop_down_list,
+            libelle: 'Type de financement',
+            drop_down_options: ['Subvention territoriale', 'Subvention communale']
+          },
+          { type: :number, libelle: 'Montant' },
+          { type: :number, libelle: 'Montant' }
+        ]
+      end
+
+      let!(:procedure_instance) { procedure }
+      let!(:dossier) { create(:dossier, :en_construction, procedure: procedure_instance, etablissement: etablissement) }
+      let!(:type_financement_tdc) { procedure_instance.draft_revision.types_de_champ.find { |tdc| tdc.libelle == 'Type de financement' } }
+      let!(:montant_territorial_tdc) { procedure_instance.draft_revision.types_de_champ.find { |tdc| tdc.libelle == 'Montant' } }
+      let!(:montant_communal_tdc) { procedure_instance.draft_revision.types_de_champ.filter { |tdc| tdc.libelle == 'Montant' }[1] }
+
+      before do
+        montant_territorial_tdc.update!(condition: ds_eq(champ_value(type_financement_tdc.stable_id), constant('Subvention territoriale')))
+        montant_communal_tdc.update!(condition: ds_eq(champ_value(type_financement_tdc.stable_id), constant('Subvention communale')))
+        dossier.reload
+      end
+
+      let(:nom_champ) { dossier.project_champs_public.find { |c| c.libelle == 'Nom du projet' } }
+      let(:type_champ) { dossier.project_champs_public.find { |c| c.libelle == 'Type de financement' } }
+      let(:montant_territorial) { dossier.project_champs_public.find { |c| c.stable_id == montant_territorial_tdc.stable_id } }
+
+      context '5. mix de champs normaux et conditionnels' do
+        let(:template) { 'Projet: --Nom du projet--, Type: --Type de financement--, Montant: --Montant--' }
+
+        before do
+          nom_champ.update(value: 'Construction fare potee')
+          type_champ.update(value: 'Subvention territoriale')
+          montant_territorial.update(value: '1500000')
+        end
+
+        subject { template_concern.send(:replace_tags, template, dossier) }
+
+        it 'substitue correctement les champs normaux et conditionnels' do
+          expect(subject).to eq('Projet: Construction fare potee, Type: Subvention territoriale, Montant: 1500000')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## La demande
Les champs conditionnels devraient apparaître dans les mails reçus par l'usager.
Le champ visible apparaît avec la valeur écrite par l'usager. Le non visible retourne une string vide

## Résultat
L'usager a répondu à la première condition :
<img width="465" height="226" alt="image" src="https://github.com/user-attachments/assets/dccf7ac4-a20f-46e6-aa1c-94b055981d58" />

L'usager a répondu à la deuxième condition :  
<img width="475" height="217" alt="image" src="https://github.com/user-attachments/assets/3aa68610-f064-4f34-8e2e-2b5fca540530" />

## Problèmes rencontrés
- Difficulté de compréhension du code déjà existant
- Avec l'ancienne méthode `def parse_tags`, les deux libellés `--Montant` pointaient vers la même ID, ce qui empêchait le bon affichage des champs. Solution qui m'a été proposée par Claude (car je bloquais complètement sur cette partie) : remplacer avec `group_by` pour conserver tous les tags ayant le même libellé, et utiliser un compteur pour associer chaque occurrence de` --Montant--` à un index différent dans le tableau 
- Il fallait aussi trier les `stable_id` par ordre décroissant pour correspondre à l'ordre d'affichage dans le template (la première condition avait pour ID `tdc173` et la seconde `tdc172`

## Autre
J'ai également supprimé les badges UI dans les attestations

## Remarques concernant la review de Claude
J'ai essayé d'ajouter plusieurs tests comme le suggère Claude dans sa review, mais même en m'aidant de Copilot pour les écrire, ils revenaient constamment avec des erreurs, un peu comme s'il s'agissait de flaky tests 🤔 Du coup je ne les ai pas push. Est-ce que ça veut dire que malgré le fait que ma solution proposée fonctionne, la logique ne soit pas la meilleure ?

Aussi concernant sa suggestion de fusionner les deux `.map()` en un seul, vu qu'il s'agissait déjà de code existant je ne l'ai pas modifié 

Enfin, je n'ai pas vraiment compris son deuxième point (appels répétés à `dossier.champs` ), donc vu que je n'ai pas compris je n'ai pas appliqué sa suggestion de remplacement par `champs_by_stable_id = dossier.champs.index_by(&:stable_id)`

(Et juste pour rappel, je suis en cours la semaine prochaine, j'espère que ça ne sera pas trop bloquant pour l'avancée)
