### PR TITLE
fix: utiliser project_champs pour éviter les champs orphelins dans Lexpol

### DIFF
--- a/app/services/lexpol_service.rb
+++ b/app/services/lexpol_service.rb
@@ -84,8 +84,10 @@ class LexpolService
     excluded_champ_classes = EXCLUDED_CHAMP_TYPES.map { |t| "Champs::#{t.to_s.camelize}Champ".constantize }
 
     # Variables des champs avec leur formatage spécial
-    dossier.champs
-      .filter { |c| !c.child? && !c.is_a?(Champs::DossierLinkChamp) }
+    # pf: Utiliser project_champs pour avoir TOUS les champs de la révision (même non touchés)
+    # et éviter les champs orphelins (stable_id supprimé de la révision)
+    (dossier.project_champs_public + dossier.project_champs_private)
+      .filter { |c| !c.is_a?(Champs::DossierLinkChamp) }
       .reject { |c| excluded_champ_classes.any? { |klass| c.is_a?(klass) } }
       .each do |champ|
         if champ.present?

--- a/app/services/linked_dossier_fields_service.rb
+++ b/app/services/linked_dossier_fields_service.rb
@@ -84,8 +84,10 @@ class LinkedDossierFieldsService
   def extract_linked_dossier_variables(linked_dossier)
     {}.tap do |variables|
       add_metadata(variables, linked_dossier)
-      add_champs(variables, linked_dossier.champs.filter { |c| !c.child? && c.present? })
-      add_champs(variables, linked_dossier.filled_champs_private) if linked_dossier.has_annotations?
+      # pf: Utiliser project_champs pour avoir TOUS les champs de la révision (même non touchés)
+      # et éviter les champs orphelins (stable_id supprimé de la révision)
+      add_champs(variables, linked_dossier.project_champs_public)
+      add_champs(variables, linked_dossier.project_champs_private) if linked_dossier.has_annotations?
     end
   end
 


### PR DESCRIPTION
## Problème

En production, l'erreur suivante se produisait lors de la création d'un dossier Lexpol :
```
Impossible de créer le dossier Lexpol. Type De Champ 154522 not found in Revision 6398
```

### Cause racine

1. Un champ Date (stable_id 154522) a été supprimé de la révision 6398
2. Lors d'une migration de révision, les `Champ` en base restent pour préserver l'historique (comportement normal de `DossierRebaseConcern`)
3. **L'affichage des dossiers fonctionne** car il utilise `project_champs_public/private` qui filtre automatiquement par révision
4. **Lexpol plantait** car il utilisait `dossier.champs` qui retourne TOUS les champs, y compris les orphelins
5. Lors de l'accès à `champ.libelle`, l'appel à `champ.type_de_champ` lève une erreur car le TypeDeChamp n'existe plus dans la révision

### Pourquoi ça marchait ailleurs ?

Le code d'affichage utilise systématiquement les méthodes qui filtrent par révision :
- `project_champs_public/private` → part de `revision.types_de_champ`
- `champs_in_revision` → filtre explicitement avec `stable_id_in_revision?`

## Solution

Remplacer `dossier.champs` par `project_champs_public + project_champs_private` dans :
- ✅ `app/services/lexpol_service.rb`
- ✅ `app/services/linked_dossier_fields_service.rb`

### Bonus de cette approche

`project_champs` inclut aussi les champs **non persistés** (non touchés) avec valeur vide, ce qui est utile pour Lexpol car :
- Les templates Lexpol attendent toutes les variables définies
- Évite les erreurs de variables manquantes dans les templates

## Tests

✅ Tous les tests passent :
- 19 exemples LexpolService
- 22 exemples LinkedDossierFieldsService  
- 9 exemples Lexpol Controller

## Action en production

Pour nettoyer les champs orphelins existants (optionnel) :

```ruby
# Console Rails production
revision = Revision.find(6398)
procedure = revision.procedure
stable_ids_revision = revision.types_de_champ.pluck(:stable_id).to_set

orphan_champs = []
procedure.dossiers.where(revision_id: 6398).find_each do |dossier|
  dossier.champs.each do |champ|
    orphan_champs << champ unless stable_ids_revision.include?(champ.stable_id)
  end
end

puts "#{orphan_champs.count} champs orphelins à supprimer"
orphan_champs.each(&:destroy)
```

⚠️ Ce nettoyage est **optionnel** car le bug est maintenant corrigé dans le code.