### PR TITLE
fix: center attestation footer

### DIFF
--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -25,13 +25,10 @@
 
   @bottom-center {
     font-size: 8pt;
-    content: counter(page) ' / ' counter(pages);
-    margin-top: 17mm;
+    content: element(footer) '\A' counter(page) ' / ' counter(pages);
     white-space: nowrap;
-  }
-
-  @bottom-left {
-    content: element(footer);
+    margin-top: 17mm;
+    text-align: center;
   }
 }
 
@@ -218,7 +215,8 @@
     position: running(footer);
     font-size: 7pt;
     font-weight: 100;
-    white-space: nowrap;
+    white-space: normal;
+    text-align: center;
 
     @media screen {
       position: absolute;


### PR DESCRIPTION
Pour le bug Weasyprint dont je t'avais fait part en début de semaine : le problème était bien que mon seveur Weasyprint ne lisait pas le css.
Vu qu'on ne lance pas l'application de la même manière, je suppose que c'est pour ça que tu n'avais pas le même problème.

Mais du coup j'ai trouvé cette solution en modifiant `attestation.html.haml`. Comme ça, le css est pris en compte de mon côté, et je ne pense pas que ça casserait quoique ce soit de ton côté ? Dis-moi ! 

Je ne pourrai m'occuper de la review de Claud qu'après ma semaine de cours, désolée 

Mais maintenant, le footer des attestations est bien centré : 
<img width="1257" height="116" alt="image" src="https://github.com/user-attachments/assets/30fd96e4-6ae3-437c-8ce2-1207bf5fabf7" />
