### PR TITLE
Feat/fix duplicate repetition bloc with condition

### DIFF
--- a/app/components/types_de_champ_editor/duplicate_champ_button_component.rb
+++ b/app/components/types_de_champ_editor/duplicate_champ_button_component.rb
@@ -6,10 +6,6 @@ class TypesDeChampEditor::DuplicateChampButtonComponent < ApplicationComponent
     @after_stable_id = after_stable_id
   end
 
-  def render?
-    !@coordinate.type_de_champ.repetition?
-  end
-
   private
 
   def procedure

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -182,22 +182,12 @@ module Administrateurs
         parent_stable_id: @coordinate.parent&.stable_id
       }
 
-      if default_type_de_champ.repetition?
-        duplicate_repetition_bloc(default_type_de_champ, new_champ_params)
-      else
-        type_de_champ = draft.add_type_de_champ(new_champ_params)
-
-        if type_de_champ.valid?
-          set_coordinate_response(type_de_champ)
-        else
-          flash.alert = type_de_champ.errors.full_messages
-        end
-      end
+      duplicate_type_de_champ(default_type_de_champ, new_champ_params)
     end
 
     private
 
-    def duplicate_repetition_bloc(default_type_de_champ, new_champ_params)
+    def duplicate_type_de_champ(default_type_de_champ, new_champ_params)
       ActiveRecord::Base.transaction do
         type_de_champ = draft.add_type_de_champ(new_champ_params)
 
@@ -206,58 +196,41 @@ module Administrateurs
           raise ActiveRecord::Rollback
         end
 
-        children = draft.children_of(default_type_de_champ)
-        last_child_stable_id = type_de_champ.stable_id
-
-        mapping = {}
-
-        children.each do |child|
-          new_child_params = {
-            type_champ: child.type_champ,
-            libelle: child.libelle.to_s,
-            description: child.description,
-            mandatory: child.mandatory,
-            options: child.options,
-            condition: child.condition,
-            private: child.private,
-            after_stable_id: last_child_stable_id,
-            parent_stable_id: type_de_champ.stable_id
-          }
-
-          child_type_de_champ = draft.add_type_de_champ(new_child_params)
-
-          unless child_type_de_champ.valid?
-            flash.alert = child_type_de_champ.errors.full_messages
-            raise ActiveRecord::Rollback
-          end
-
-          mapping[child.stable_id] = child_type_de_champ.stable_id
-
-          if child.condition.present?
-            new_condition = replace_stable_ids_in_condition(child.condition, mapping)
-            child_type_de_champ.condition = new_condition
-            child_type_de_champ.save!
-          end
-          last_child_stable_id = child_type_de_champ.stable_id
+        if default_type_de_champ.repetition?
+          duplicate_children(default_type_de_champ, type_de_champ)
         end
+
         set_coordinate_response(type_de_champ)
       end
     end
 
-    def replace_stable_ids_in_condition(condition, mapping)
-      return nil if condition.nil?
+    def duplicate_children(default_type_de_champ, type_de_champ)
+      children = draft.children_of(default_type_de_champ)
+      last_child_stable_id = type_de_champ.stable_id
+      mapping = {}
 
-      if condition.is_a?(Logic::ChampValue)
-        new_stable_id = mapping[condition.stable_id] || condition.stable_id
-        Logic::ChampValue.new(new_stable_id)
-      elsif condition.respond_to?(:left) && condition.respond_to?(:right)
-        new_left = replace_stable_ids_in_condition(condition.left, mapping)
-        condition.class.new(new_left, condition.right)
-      elsif condition.respond_to?(:operands)
-        new_operands = condition.operands.map { |op| replace_stable_ids_in_condition(op, mapping) }
-        condition.class.new(new_operands)
-      else
-        condition
+      children.each do |child|
+        new_child_params = {
+          type_champ: child.type_champ,
+          libelle: child.libelle.to_s,
+          description: child.description,
+          mandatory: child.mandatory,
+          options: child.options,
+          condition: child.condition&.dup_with_stable_ids(mapping),
+          private: child.private,
+          after_stable_id: last_child_stable_id,
+          parent_stable_id: type_de_champ.stable_id
+        }
+
+        child_type_de_champ = draft.add_type_de_champ(new_child_params)
+
+        unless child_type_de_champ.valid?
+          flash.alert = child_type_de_champ.errors.full_messages
+          raise ActiveRecord::Rollback
+        end
+
+        mapping[child.stable_id] = child_type_de_champ.stable_id
+        last_child_stable_id = child_type_de_champ.stable_id
       end
     end
 

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -182,46 +182,91 @@ module Administrateurs
         parent_stable_id: @coordinate.parent&.stable_id
       }
 
-      type_de_champ = draft.add_type_de_champ(new_champ_params)
-
-      if type_de_champ.valid?
-        @coordinate = draft.coordinate_for(type_de_champ)
-        ProcedureRevisionPreloader.load_one(@coordinate.revision)
-        @created = champ_component_from(@coordinate, focused: true)
-        @morphed = champ_components_starting_at(@coordinate, 1)
-      else
-        flash.alert = type_de_champ.errors.full_messages
-      end
-
       if default_type_de_champ.repetition?
-        ActiveRecord::Base.transaction do
-          children = draft.children_of(default_type_de_champ)
-          last_child_stable_id = type_de_champ.stable_id
+        duplicate_repetition_bloc(default_type_de_champ, new_champ_params)
+      else
+        type_de_champ = draft.add_type_de_champ(new_champ_params)
 
-          children.each do |child|
-            new_child_params = draft.add_type_de_champ(
-              {
-                type_champ: child.type_champ,
-                libelle: child.libelle.to_s,
-                description: child.description,
-                mandatory: child.mandatory,
-                options: child.options,
-                condition: child.condition,
-                parent_stable_id: type_de_champ.stable_id,
-                after_stable_id: last_child_stable_id
-              }
-            )
-            unless new_child_params.valid?
-              flash.alert = new_child_params.errors.full_messages
-              raise ActiveRecord::Rollback
-            end
-            last_child_stable_id = new_child_params.stable_id
-          end
+        if type_de_champ.valid?
+          set_coordinate_response(type_de_champ)
+        else
+          flash.alert = type_de_champ.errors.full_messages
         end
       end
     end
 
     private
+
+    def duplicate_repetition_bloc(default_type_de_champ, new_champ_params)
+      ActiveRecord::Base.transaction do
+        type_de_champ = draft.add_type_de_champ(new_champ_params)
+
+        unless type_de_champ.valid?
+          flash.alert = type_de_champ.errors.full_messages
+          raise ActiveRecord::Rollback
+        end
+
+        children = draft.children_of(default_type_de_champ)
+        last_child_stable_id = type_de_champ.stable_id
+
+        mapping = {}
+
+        children.each do |child|
+          new_child_params = {
+            type_champ: child.type_champ,
+            libelle: child.libelle.to_s,
+            description: child.description,
+            mandatory: child.mandatory,
+            options: child.options,
+            condition: child.condition,
+            private: child.private,
+            after_stable_id: last_child_stable_id,
+            parent_stable_id: type_de_champ.stable_id
+          }
+
+          child_type_de_champ = draft.add_type_de_champ(new_child_params)
+
+          unless child_type_de_champ.valid?
+            flash.alert = child_type_de_champ.errors.full_messages
+            raise ActiveRecord::Rollback
+          end
+
+          mapping[child.stable_id] = child_type_de_champ.stable_id
+
+          if child.condition.present?
+            new_condition = replace_stable_ids_in_condition(child.condition, mapping)
+            child_type_de_champ.condition = new_condition
+            child_type_de_champ.save!
+          end
+          last_child_stable_id = child_type_de_champ.stable_id
+        end
+        set_coordinate_response(type_de_champ)
+      end
+    end
+
+    def replace_stable_ids_in_condition(condition, mapping)
+      return nil if condition.nil?
+
+      if condition.is_a?(Logic::ChampValue)
+        new_stable_id = mapping[condition.stable_id] || condition.stable_id
+        Logic::ChampValue.new(new_stable_id)
+      elsif condition.respond_to?(:left) && condition.respond_to?(:right)
+        new_left = replace_stable_ids_in_condition(condition.left, mapping)
+        condition.class.new(new_left, condition.right)
+      elsif condition.respond_to?(:operands)
+        new_operands = condition.operands.map { |op| replace_stable_ids_in_condition(op, mapping) }
+        condition.class.new(new_operands)
+      else
+        condition
+      end
+    end
+
+    def set_coordinate_response(type_de_champ)
+      @coordinate = draft.coordinate_for(type_de_champ)
+      ProcedureRevisionPreloader.load_one(@coordinate.revision)
+      @created = champ_component_from(@coordinate, focused: true)
+      @morphed = champ_components_starting_at(@coordinate, 1)
+    end
 
     def changing_of_type?(type_de_champ)
       type_de_champ_update_params['type_champ'].present? && (type_de_champ_update_params['type_champ'] != type_de_champ.type_champ)

--- a/app/models/logic/binary_operator.rb
+++ b/app/models/logic/binary_operator.rb
@@ -11,6 +11,10 @@ class Logic::BinaryOperator < Logic::Term
     [@left, @right].flat_map(&:sources)
   end
 
+  def dup_with_stable_ids(mapping)
+    self.class.new(@left.dup_with_stable_ids(mapping), @right.dup_with_stable_ids(mapping))
+  end
+
   def to_h
     {
       "term" => self.class.name,

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -52,6 +52,10 @@ class Logic::ChampValue < Logic::Term
     [@stable_id]
   end
 
+  def dup_with_stable_ids(mapping)
+    self.class.new(mapping[stable_id] || stable_id)
+  end
+
   def compute(champs)
     targeted_champ = champ(champs)
 

--- a/app/models/logic/n_ary_operator.rb
+++ b/app/models/logic/n_ary_operator.rb
@@ -11,6 +11,10 @@ class Logic::NAryOperator < Logic::Term
     @operands.flat_map(&:sources)
   end
 
+  def dup_with_stable_ids(mapping)
+    self.class.new(@operands.map { |op| op.dup_with_stable_ids(mapping) })
+  end
+
   def to_h
     {
       "term" => self.class.name,

--- a/app/models/logic/term.rb
+++ b/app/models/logic/term.rb
@@ -4,4 +4,8 @@ class Logic::Term
   def to_json
     to_h.to_json
   end
+
+  def dup_with_stable_ids(_mapping)
+    self
+  end
 end

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -201,6 +201,7 @@ describe Administrateurs::TypesDeChampController, type: :controller do
 
       context 'when the csv file is iso-8859 format, with CRLF line terminators and special characters (even in header)' do
         let(:referentiel_file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel-iso-8859-crlf-special-characters.csv', 'text/csv') }
+
         it 'works' do
           expect { subject }.to change(Referentiel, :count).by(1).and change(ReferentielItem, :count).by(2)
           expect(ReferentielItem.first.data).to eq({ "row" => { "adresse" => "115, Boulevard Exelmans, Paris, 75016", "email" => "moha.ali@diplomatie.gouv.fr", "nom" => "Mohamed Ali", "numero" => "UK +447 864 743 320" } })
@@ -392,100 +393,137 @@ describe Administrateurs::TypesDeChampController, type: :controller do
         created_champ = assigns(:created).coordinate.type_de_champ
         expect(created_champ.options).to eq({ 'min' => 10, 'max' => 100 })
       end
-    end
 
-    context 'duplicate repetition bloc with children' do
-      let(:procedure_with_repetition) do
-        create(:procedure,
-               types_de_champ_public: [
-                 { type: :integer_number, libelle: 'l1' },
-                 {
-                   type: :repetition,
-                   libelle: 'Vos enfants',
-                   children: [
-                     { type: :text, libelle: 'Nom' },
-                     { type: :text, libelle: 'Prénom' },
-                     { type: :integer_number, libelle: 'Age' }
-                   ]
-                 }
-               ])
-      end
+      context 'duplicate repetition bloc' do
+        let(:procedure) do
+          create(:procedure,
+                 types_de_champ_public: [
+                   {
+                     type: :yes_no,
+                     libelle: 'Destination',
+                     options: ['Local', 'International']
+                   },
+                   {
+                     type: :repetition,
+                     libelle: 'Produits',
+                     children: [
+                       {
+                         type: :drop_down_list,
+                         libelle: 'Type',
+                         options: ['Importation', 'Fabrication']
+                       },
+                       {
+                         type: :text,
+                         libelle: 'Pays'
+                       },
+                       {
+                         type: :text,
+                         libelle: 'Ville'
+                       }
+                     ]
+                   }
+                 ])
+        end
 
-      def repetition_coordinate = procedure_with_repetition.draft_revision.revision_types_de_champ_public.reload.second
-      def first_child_coordinate = procedure_with_repetition.draft_revision.children_of(repetition_coordinate.type_de_champ).first
-      def second_child_coordinate = procedure_with_repetition.draft_revision.children_of(repetition_coordinate.type_de_champ).second
-      def third_child_coordinate = procedure_with_repetition.draft_revision.children_of(repetition_coordinate.type_de_champ).third
+        let(:repetition_coordinate) do
+          procedure.draft_revision.revision_types_de_champ_public.second
+        end
 
-      context 'when duplicating the whole repetition bloc' do
         let(:params) do
           {
-            procedure_id: procedure_with_repetition.id,
+            procedure_id: procedure.id,
             stable_id: repetition_coordinate.stable_id
           }
         end
 
-        it 'duplicates the repetition bloc with its children' do
-          subject
-          duplicated_coordinate = assigns(:created).coordinate
-          children = procedure_with_repetition.draft_revision.children_of(duplicated_coordinate.type_de_champ)
+        subject { post :duplicate, params: params, format: :turbo_stream }
 
-          is_expected.to have_http_status(:ok)
-          expect(flash.alert).to eq(nil)
-          expect(children.count).to eq(3)
+        def destination_coordinate
+          procedure.draft_revision.revision_types_de_champ_public.first
+        end
+
+        def children_coordinates
+          procedure.draft_revision.children_of(repetition_coordinate)
+        end
+
+        context 'duplicate bloc with all children' do
+          it 'duplicates the bloc and all its children' do
+            expect { subject }.to change {
+              procedure.draft_revision.types_de_champ.where(type_champ: 'repetition').count
+            }.by(1).and change {
+              procedure.draft_revision.types_de_champ.count
+            }.by(4)
+
+            expect(flash.alert).to be_nil
+
+            duplicated_bloc = procedure.draft_revision.types_de_champ.where(type_champ: 'repetition').last
+            expect(duplicated_bloc.libelle).to eq('Produits')
+
+            duplicated_children = procedure.draft_revision.children_of(duplicated_bloc)
+            expect(duplicated_children.count).to eq(3)
+            expect(duplicated_children.map(&:libelle)).to eq(['Type', 'Pays', 'Ville'])
+          end
+        end
+
+        context 'duplicate bloc with child having external condition' do
+          before do
+            ville_tdc = children_coordinates.last
+
+            ville_tdc.update!(
+              condition: Logic::Eq.new(
+                Logic::ChampValue.new(destination_coordinate.stable_id),
+                Logic::Constant.new('International')
+              )
+            )
+          end
+
+          it 'duplicates the bloc and keeps external condition unchanged' do
+            original_destination_stable_id = destination_coordinate.stable_id
+
+            expect { subject }.to change {
+              procedure.draft_revision.types_de_champ.count
+            }.by(4)
+
+            duplicated_bloc_coordinate = procedure.draft_revision.revision_types_de_champ_public.last
+            duplicated_ville = procedure.draft_revision.children_of(duplicated_bloc_coordinate).last
+
+            expect(duplicated_ville.condition).to be_present
+            expect(duplicated_ville.condition.sources).to eq([original_destination_stable_id])
+          end
+        end
+
+        context 'duplicate bloc with child having internal condition' do
+          before do
+            type_tdc = children_coordinates.first
+            pays_tdc = children_coordinates.second
+
+            pays_tdc.update!(
+              condition: Logic::Eq.new(
+                Logic::ChampValue.new(type_tdc.stable_id),
+                Logic::Constant.new('Importation')
+              )
+            )
+          end
+
+          it 'duplicates the bloc and transforms internal condition stable_id' do
+            original_type_stable_id = children_coordinates.first.stable_id
+
+            expect { subject }.to change {
+              procedure.draft_revision.types_de_champ.count
+            }.by(4)
+
+            procedure.draft_revision.reload
+            duplicated_bloc_coordinate = procedure.draft_revision.revision_types_de_champ_public.last
+            duplicated_type = procedure.draft_revision.children_of(duplicated_bloc_coordinate).first
+            duplicated_pays = procedure.draft_revision.children_of(duplicated_bloc_coordinate).second
+
+            expect(duplicated_pays.condition).to be_present
+
+            expect(duplicated_pays.condition.sources.first).to eq(duplicated_type.stable_id)
+            expect(duplicated_pays.condition.sources.first).not_to eq(original_type_stable_id)
+          end
         end
       end
-
-      context 'when duplicating a child inside the repetition bloc' do
-          let(:params) do
-            {
-              procedure_id: procedure_with_repetition.id,
-              stable_id: second_child_coordinate.stable_id
-            }
-          end
-
-          it 'duplicates the child' do
-              subject
-
-              is_expected.to have_http_status(:ok)
-              expect(flash.alert).to eq(nil)
-
-              duplicated_coordinate = assigns(:created).coordinate
-              expect(duplicated_coordinate.libelle).to eq('Prénom')
-              expect(duplicated_coordinate.parent_id).to eq(repetition_coordinate.id)
-            end
-
-          context 'when duplicating a repetition bloc fails' do
-            let(:params) do
-              {
-                procedure_id: procedure_with_repetition.id,
-                stable_id: repetition_coordinate.stable_id
-              }
-            end
-
-            before do
-              allow_any_instance_of(ProcedureRevision).to receive(:add_type_de_champ).and_wrap_original do |method, *args|
-                result = method.call(*args)
-
-                if args.first[:parent_stable_id].nil? && args.first[:type_champ] == 'repetition'
-                  allow(result).to receive(:valid?).and_return(false)
-                  allow(result).to receive_message_chain(:errors, :full_messages).and_return(['Erreur lors de la duplication'])
-                end
-                result
-              end
-            end
-            it 'does not duplicate children when parent is invalid' do
-              initial_count = procedure_with_repetition.draft_revision.revision_types_de_champ_public.count
-
-              subject
-
-              is_expected.to have_http_status(:ok)
-              expect(flash.alert).to eq(['Erreur lors de la duplication'])
-              final_count = procedure_with_repetition.draft_revision.revision_types_de_champ_public.reload.count
-
-              expect(final_count).to eq(initial_count + 1)
-            end
-          end
-        end
     end
   end
 end


### PR DESCRIPTION
### La demande
Lors de la duplication des blocs répétables, si un enfant ayant une condition faisant appel à un champ extérieur la duplication se faisait parfaitement bien.
Or, si un enfant avait une condition faisant appel à un autre champ enfant du bloc répétable, les conditions ne se dupliquaient pas.

### Le problème
Les `stable_id` pointaient en fait encore vers les anciens `stable_id`
J'ai bien rassemblé les deux boucles en une seule, et effectivement ça simplifie clairement le code !
Effectivement, la variable `new_right` n'était pas nécessaire , avec les logs j'ai pu bien voir que `:right` n'est pas un `ChampValue`

### Extrait du bloc répétable avec les conditions des enfants
<img width="820" height="846" alt="image" src="https://github.com/user-attachments/assets/6b543b0e-beb4-40f3-959b-fc81bd2b956d" />

### Extrait de la duplication du bloc répétable avec les conditions internes des enfants
<img width="809" height="869" alt="image" src="https://github.com/user-attachments/assets/2b1be544-d4ec-4255-8962-cd5963aa95d7" />
