### PR TITLE
Fix: pré-chauffer les previews PJ avant accepter!

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -246,6 +246,7 @@ module Instructeurs
           dossier.classer_sans_suite!(h)
           flash.notice = "Dossier considéré comme sans suite."
         when "accepter"
+          warm_pj_previews(dossier)
           target_state = :accepte
           dossier.accepter!(h)
           flash.notice = "Dossier traité avec succès."
@@ -437,6 +438,29 @@ module Instructeurs
     end
 
     private
+
+    # pf: Pré-génère les variants/previews des PJ pour éviter qu'ils soient générés
+    # à l'intérieur de la transaction AASM de accepter!.
+    #
+    # Contexte : ActiveStorage en Rails 7.1 diffère l'upload S3 dans after_commit.
+    # Quand un variant est généré dans une transaction, le Tempfile source est
+    # supprimé par image_processing avant que after_commit ne puisse l'uploader.
+    # En pré-générant hors transaction, after_commit s'exécute immédiatement.
+    def warm_pj_previews(dossier)
+      dossier.filled_champs.each do |champ|
+        next unless champ.respond_to?(:piece_justificative_file)
+
+        champ.piece_justificative_file.each do |attachment|
+          if attachment.image?
+            attachment.variant(resize_to_limit: [400, 400]).processed
+          elsif attachment.previewable?
+            attachment.preview(resize_to_limit: [400, 400]).processed
+          end
+        rescue StandardError => e
+          Rails.logger.warn "warm_pj_previews: #{attachment.filename} - #{e.class}: #{e.message}"
+        end
+      end
+    end
 
     def avis_create_params
       params.require(:avis).permit(


### PR DESCRIPTION
## Summary

- Corrige l'erreur `Errno::ENOENT` lors de l'acceptation de dossiers avec PJ sur une procédure avec attestation contenant des tags PJ
- Pré-génère les variants/previews des PJ **avant** l'appel à `accepter!` pour éviter le conflit entre le Tempfile d'image_processing et le `after_commit` différé d'ActiveStorage dans la transaction AASM

## Cause racine

ActiveStorage en Rails 7.1 diffère l'upload S3 dans `after_commit`. Quand un variant est généré **dans** la transaction AASM de `accepter!`, le Tempfile source est supprimé par `image_processing` (`ensure output.close!`) avant que `after_commit` ne puisse l'uploader → `Errno::ENOENT`.

Le résultat : le variant et l'attestation PDF sont en DB mais absents de S3.

## Fix

Appeler `warm_pj_previews(dossier)` avant `accepter!`, hors transaction. Les variants sont générés et uploadés immédiatement. Lors de `accepter!`, `variant.processed` trouve le variant déjà traité et ne re-déclenche pas le processing.

## Test plan

- [ ] Créer un dossier avec PJ (image ou PDF) sur une procédure avec attestation contenant un tag PJ
- [ ] Accepter le dossier
- [ ] Vérifier que l'attestation PDF est générée et téléchargeable
- [ ] Vérifier dans les logs qu'il n'y a pas d'erreur `Errno::ENOENT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)