### PR TITLE
fix: referentiel de polynésie — vue dossier et protection fork

### DIFF
--- a/app/models/champs/referentiel_de_polynesie_champ.rb
+++ b/app/models/champs/referentiel_de_polynesie_champ.rb
@@ -2,7 +2,11 @@
 
 class Champs::ReferentielDePolynesieChamp < Champs::ReferentielChamp
   # pf: préserver le label humain dans value (upstream y met external_id)
+  # pf: guard new_record? pour éviter que le fork (deep_clone) ne wipe data/value_json
+  # sur les champs clonés — external_id_changed? est toujours true sur un new_record
   def clear_previous_result
+    return if new_record? && data.present?
+
     self.data = nil
     self.value_json = nil
     self.fetch_external_data_exceptions = []

--- a/app/views/shared/champs/referentiel_de_polynesie/_show.html.haml
+++ b/app/views/shared/champs/referentiel_de_polynesie/_show.html.haml
@@ -11,7 +11,8 @@
       %table.table.vertical.dossier-champs
         %tbody
           - data = champ.data
-          - row = data['row']
+          -# pf: dual-mode — ancien format (avec row) et nouveau format (plat)
+          - row = data.key?('row') ? data['row'] : data
           - fields = data["#{profile}_fields"].presence || row.keys
           - fields.each do |name|
             - value = row.key?(name) ? (row[name] || "") : "Champ #{name} inconnu"


### PR DESCRIPTION
## Summary

- Fix crash `undefined method 'keys' for nil` dans la vue `_show` des champs referentiel de polynésie : support dual-mode ancien format (avec `row`) et nouveau format (plat)
- Protéger les champs referentiel contre le wipe de `data`/`value_json` lors du fork (deep_clone) : le `before_save :clear_previous_result` se déclenchait sur les clones car `external_id_changed?` est toujours true sur un `new_record`

## Contexte

Après merge de la PR d'harmonisation, deux bugs sont apparus en staging :
1. Les dossiers existants (ancien format avec `data['row']`) crashaient à l'affichage
2. La modification d'un dossier en_construction provoquait "En attente de réponse" sur des champs referentiel non modifiés, à cause du mécanisme de fork qui wipe les données clonées

Le guard `new_record? && data.present?` protège les **991 forks actifs en prod**. L'activation du flag `user_buffer_stream` (mode stream, sans fork) est recommandée après déploiement via `Flipper.enable(:user_buffer_stream)`.

## Test plan

- [ ] Afficher un dossier avec des champs referentiel ancien format (avec `row`) → pas de crash
- [ ] Afficher un dossier avec des champs referentiel nouveau format (plat) → pas de crash
- [ ] Modifier un dossier en_construction avec fork, déposer → pas d'erreur "en attente de réponse"
- [ ] Après activation `Flipper.enable(:user_buffer_stream)` : nouvelles modifications passent en stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)