### PR TITLE
fix(perf): N+1 queries DossierNotification.create_notification

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -8,6 +8,11 @@ module Administrateurs
     before_action :retrieve_procedure
     before_action :reload_procedure_with_includes, only: [:destroy]
 
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      flash.alert = e.message
+      head :not_found
+    end
+
     def create
       type_de_champ = draft.add_type_de_champ(type_de_champ_create_params)
       if type_de_champ.valid?

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -34,12 +34,11 @@ class DossierNotification < ApplicationRecord
 
   scope :type_news, -> { where(notification_type: [:dossier_modifie, :message, :annotation_instructeur, :avis_externe]) }
 
+  # pf: bulk insert pour éviter N+1 queries (SELECT+SELECT+INSERT par instructeur)
+  # Fixes MES-DEMARCHES-30X
   def self.create_notification(dossier, notification_type, except_instructeur: nil)
     instructeur_ids = instructeur_to_notify_ids(dossier, notification_type, except_instructeur)
-
-    instructeur_ids.each do |instructeur_id|
-      find_or_create_notification(dossier, notification_type, instructeur_id)
-    end
+    bulk_find_or_create_notifications(dossier, notification_type, instructeur_ids)
   end
 
   def self.refresh_notifications_instructeur_for_dossier_by_choice(instructeur, dossier, choice)
@@ -52,7 +51,7 @@ class DossierNotification < ApplicationRecord
     return if notification_types_to_refresh.empty?
 
     notification_types_to_refresh.each do |notification_type|
-      find_or_create_notification(dossier, notification_type, instructeur.id) if REFRESH_CONDITIONS_BY_TYPE[notification_type].call(dossier, instructeur.id)
+      bulk_find_or_create_notifications(dossier, notification_type, [instructeur.id]) if REFRESH_CONDITIONS_BY_TYPE[notification_type].call(dossier, instructeur.id)
     end
   end
 
@@ -249,19 +248,32 @@ class DossierNotification < ApplicationRecord
       .count
   end
 
-  private
+  # pf: remplace find_or_create_notification en boucle (N+1) par 1 SELECT + 1 INSERT bulk
+  def self.bulk_find_or_create_notifications(dossier, notification_type, instructeur_ids, display_at: nil)
+    return if instructeur_ids.empty?
 
-  def self.find_or_create_notification(dossier, notification_type, instructeur_id)
-    display_at = notification_type == :dossier_depose ? (dossier.depose_at + DossierNotification::DELAY_DOSSIER_DEPOSE) : Time.zone.now
+    display_at ||= notification_type.to_sym == :dossier_depose ? (dossier.depose_at + DELAY_DOSSIER_DEPOSE) : Time.zone.now
 
-    DossierNotification.find_or_create_by!(
-      dossier:,
-      notification_type:,
-      instructeur_id:
-    ) do |notification|
-      notification.display_at = display_at
-    end
+    existing_ids = where(dossier:, notification_type:, instructeur_id: instructeur_ids)
+      .pluck(:instructeur_id)
+
+    new_ids = instructeur_ids - existing_ids
+    return if new_ids.empty?
+
+    now = Time.current
+    insert_all(new_ids.map do |instructeur_id|
+      {
+        dossier_id: dossier.id,
+        notification_type: notification_type.to_s,
+        instructeur_id: instructeur_id,
+        display_at: display_at,
+        created_at: now,
+        updated_at: now
+      }
+    end)
   end
+
+  private
 
   def self.instructeur_preferences(instructeur, procedure)
     if (instructeur_procedure = InstructeursProcedure.find_by(instructeur:, procedure:))

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -70,6 +70,8 @@ class ProcedureRevision < ApplicationRecord
   def find_and_ensure_exclusive_use(stable_id)
     coordinate, tdc = coordinate_and_tdc(stable_id)
 
+    raise ActiveRecord::RecordNotFound, "Le champ n'existe plus sur ce formulaire. Il a peut-être été supprimé entre temps. Rechargez la page." if tdc.nil?
+
     if tdc.only_present_on_draft?
       tdc
     else

--- a/app/views/administration_mailer/_field_table.haml
+++ b/app/views/administration_mailer/_field_table.haml
@@ -10,6 +10,6 @@
   %tbody
     - types_de_champ.each do |champ|
       = render partial: "field_description", locals: { champ: champ, repetition: false }
-      - repetition_type_de_champs = procedure.all_revisions_types_de_champ(champ)
+      - repetition_type_de_champs = procedure.all_revisions_types_de_champ(parent: champ)
       - repetition_type_de_champs.each do |repetition_type_de_champ|
         = render partial: "field_description", locals: { champ: repetition_type_de_champ, repetition: true }


### PR DESCRIPTION
## Summary

- Corrige une N+1 query détectée par Sentry (MES-DEMARCHES-30X) dans `DossierNotification.create_notification`
- Remplace la boucle `find_or_create_notification` par instructeur (SELECT+INSERT par instructeur) par un bulk `SELECT` + `INSERT` (2 requêtes)
- Adapté à la nouvelle architecture avec `instructeur_to_notify_ids` et préférences de notification

## Détail technique

La méthode `create_notification` appelait `find_or_create_notification` en boucle sur chaque instructeur. La nouvelle méthode `bulk_find_or_create_notifications` :
1. Récupère en une seule requête les `instructeur_id` ayant déjà une notification
2. Insère en bulk les notifications manquantes via `insert_all`

Également appliqué à `refresh_notifications_instructeur_for_dossier_by_choice`.

### Autres correctifs inclus
- `ProcedureRevision#find_and_ensure_exclusive_use` : guard `tdc.nil?` pour éviter un crash si le champ a été supprimé entre temps
- `TypesDeChampController` : `rescue_from ActiveRecord::RecordNotFound` pour gérer proprement le cas
- `_field_table.haml` : correction appel `all_revisions_types_de_champ(parent: champ)` (keyword argument)

## Test plan

- [x] `bundle exec rspec spec/models/dossier_notification_spec.rb` — 24 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)