### PR TITLE
Feature : re-add '$' sign for referentiel

### DIFF
--- a/app/components/referentiels/mapping_form_base.rb
+++ b/app/components/referentiels/mapping_form_base.rb
@@ -33,9 +33,10 @@ class Referentiels::MappingFormBase < ApplicationComponent
     "type_de_champ[referentiel_mapping][#{self.class.jsonpath_to_simili(jsonpath)}][#{attribute_name}]"
   end
 
-  def display_jsonpath(jsonpath)
-    jsonpath.delete_prefix('$.')
-  end
+  # pf : TODO possibly uncomment later, but for now it make a lot of edge case when version upgrade
+  # def display_jsonpath(jsonpath)
+  #   jsonpath.delete_prefix('$.')
+  # end
 
   def bordered_container_class_names
     "border-background-contrast-grey fr-p-4w"

--- a/app/components/referentiels/mapping_form_component.rb
+++ b/app/components/referentiels/mapping_form_component.rb
@@ -32,7 +32,7 @@ class Referentiels::MappingFormComponent < Referentiels::MappingFormBase
   def enabled_libelle_tag(jsonpath)
     text_field_tag(
       attribute_name(jsonpath, "libelle"),
-      lookup_existing_value(jsonpath, "libelle") || display_jsonpath(jsonpath),
+      lookup_existing_value(jsonpath, "libelle") || jsonpath,
       libelle_field_options(jsonpath)
     )
   end

--- a/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
+++ b/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
@@ -30,8 +30,8 @@
                   - last_request_keys.sort.each do |jsonpath, example_value|
                     %tr{ data: { controller: "referentiel-mapping" } }
                       %td.fr-cell--fixed
-                        %span.hidden{ id: label_check_prefill(jsonpath) }= "Utiliser #{display_jsonpath(jsonpath)} pour préremplir le formulaire"
-                        = display_jsonpath(jsonpath)
+                        %span.hidden{ id: label_check_prefill(jsonpath) }= "Utiliser #{jsonpath} pour préremplir le formulaire"
+                        = jsonpath
                         = hidden_field_tag attribute_name(jsonpath, "example_value"), example_value
                       %td.fr-cell--multiline= example_value
                       %td= cast_tag(jsonpath, example_value)

--- a/app/components/referentiels/referentiel_display_component/referentiel_display_component.html.haml
+++ b/app/components/referentiels/referentiel_display_component/referentiel_display_component.html.haml
@@ -15,7 +15,7 @@
           %tbody
             - display_mapping.sort.each do |jsonpath, mapping_opts|
               %tr
-              %td.fr-cell--fixed= display_jsonpath(jsonpath)
+              %td.fr-cell--fixed= jsonpath
               %td.fr-cell--multiline= mapping_opts[:example_value] || mapping_opts["example_value"]
               %td= mapping_opts[:type] || mapping_opts["type"]
               %td= mapping_opts[:libelle] || mapping_opts["libelle"]

--- a/spec/components/referentiels/mapping_form_component_spec.rb
+++ b/spec/components/referentiels/mapping_form_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Referentiels::MappingFormComponent, type: :component do
 
         # tbody
         jsonpaths = page.all("tr td:nth-child(1)").map(&:text).map(&:strip)
-        ["point.type", "point.coordinates", "shape.type"].each do |sample|
+        ["$.point.type", "$.point.coordinates", "$.shape.type"].each do |sample|
           expect(jsonpaths).to include("Utiliser #{sample} pour préremplir le formulaire\n#{sample}")
         end
         values = page.all("tr td:nth-child(2)").map(&:text).map(&:strip)

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -81,13 +81,13 @@ describe 'Referentiel API:' do
     ##
     # choose prefill stable ids
     ###
-    expect(page).to have_content("status")
+    expect(page).to have_content("$.status")
     page.find("select[name='type_de_champ[referentiel_mapping][$.status][prefill_stable_id]']")
       .select('prefill with $.statut')
     # one boolean champ, nothing to select
-    expect(page).to have_content("is_active")
+    expect(page).to have_content("$.is_active")
     # choose another stable than the default one for the repetition
-    expect(page).to have_content("addresses[0].street")
+    expect(page).to have_content("$.addresses[0].street")
     page.find("select[name='type_de_champ[referentiel_mapping][$.addresses{0}.street][prefill_stable_id]']")
       .select('repetition - prefill with $.addresses[0].street')
     ##
@@ -196,14 +196,14 @@ describe 'Referentiel API:' do
         visit demande_dossier_path(created_dossier)
         expect(page).to have_content("Coordonées du point : -0.570505392116188, 44.841034137099996")
         expect(page).to have_content("Type de point : Point")
-        expect(page).not_to have_content("shape.type") # not displayed to usager
+        expect(page).not_to have_content("$.shape.type") # not displayed to usager
 
         # check data is also visible on demande page as an usager
         visit instructeur_dossier_path(procedure, created_dossier)
         expect(page).to have_content("Sections du formulaire")
         expect(page).not_to have_content("Coordonées du point")
         expect(page).to have_content("Type de point")
-        expect(page).to have_content("shape.type")
+        expect(page).to have_content("$.shape.type")
       end
     end
   end


### PR DESCRIPTION
On re-ajoute le signe '$' => En le retirant on a une avalanche de petits soucis sur les montées de versions