### PR TITLE
fix: supprime le job cron orphelin NotifyOldBrouillonDossiersSoonDeletedJob

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -11,6 +11,23 @@ namespace :jobs do
     schedulable_jobs.each(&:display_schedule)
   end
 
+  desc 'Remove orphaned cron jobs from Sidekiq::Cron (classes no longer in codebase)'
+  task remove_orphaned: :environment do
+    orphaned = Sidekiq::Cron::Job.all.filter do |job|
+      job.klass.safe_constantize.nil?
+    end
+
+    if orphaned.empty?
+      puts "No orphaned cron jobs found."
+    else
+      orphaned.each do |job|
+        puts "Removing orphaned cron job: #{job.name}"
+        job.destroy
+      end
+      puts "Done. Removed #{orphaned.size} orphaned cron job(s)."
+    end
+  end
+
   def schedulable_jobs
     glob = Rails.root.join('app', 'jobs', '**', '*_job.rb')
     Dir.glob(glob).each { |f| require f }


### PR DESCRIPTION
Resolve #316 
Lancer le job en console : `bundle exec rake jobs:remove_orphaned`