### PR TITLE
feature: reduce gap for instructeurs

### DIFF
--- a/app/assets/stylesheets/instructeur_layout.scss
+++ b/app/assets/stylesheets/instructeur_layout.scss
@@ -1,0 +1,11 @@
+body.nav-profile-instructeur {
+  .fr-container {
+    @media (min-width: 78em) {
+      max-width: 120rem;
+    }
+  }
+
+  .container {
+    max-width: 100rem;
+  }
+}

--- a/app/views/instructeurs/dossiers/annotations_privees.html.haml
+++ b/app/views/instructeurs/dossiers/annotations_privees.html.haml
@@ -7,5 +7,5 @@
     .fr-grid-row.fr-grid-row--center
       - summary = ViewableChamp::HeaderSectionsSummaryComponent.new(dossier: @dossier, is_private: true)
       = render summary
-      %div{ class: class_names("fr-col-12", "fr-col-xl-9" => summary.render?, "fr-col-xl-8" => !summary.render?) }
+      %div{ class: class_names("fr-col-12", "fr-col-xl-9" => summary.render?, "fr-col-xl-10" => !summary.render?) }
         = render partial: "shared/dossiers/edit_annotations", locals: { dossier: @dossier, seen_at: @annotations_privees_seen_at }

--- a/app/views/instructeurs/dossiers/show.html.haml
+++ b/app/views/instructeurs/dossiers/show.html.haml
@@ -18,5 +18,5 @@
   .fr-grid-row.fr-grid-row--center
     - summary = ViewableChamp::HeaderSectionsSummaryComponent.new(dossier: @dossier, is_private: false)
     = render summary
-    %div{ class: class_names("fr-col-12", "fr-col-xl-9" => summary.render?, "fr-col-xl-8" => !summary.render?) }
+    %div{ class: class_names("fr-col-12", "fr-col-xl-9" => summary.render?, "fr-col-xl-10" => !summary.render?) }
       = render partial: "shared/dossiers/demande", locals: { dossier: @dossier, demande_seen_at: @demande_seen_at, profile: 'instructeur' }

--- a/app/views/layouts/application.html.herb
+++ b/app/views/layouts/application.html.herb
@@ -66,9 +66,11 @@
       <meta name="robots" content="<%= content_for(:meta_robots) %>">
     <% end %>
   </head>
+  <%# pf: expose le profil courant sur la balise body afin de pouvoir scoper des styles (ex. largeur du container) par profil %>
+  <% nav_bar_profile = controller.try(:nav_bar_profile) || controller.try(:fallback_nav_bar_profile) || :guest %>
   <body
     id="<%= content_for(:page_id) %>"
-    class="<%= browser.platform.ios? ? 'ios' : '' %>"
+    class="<%= class_names('ios' => browser.platform.ios?, "nav-profile-#{nav_bar_profile}" => nav_bar_profile.present?) %>"
     data-controller="turbo number-input fix-table-border"
   >
     <%= render partial: 'layouts/skiplinks' %>


### PR DESCRIPTION
Suite aux retours d'instructeurs trouvant les marges conséquentes : réduction des marges latérales pour les instructeurs pour permettre d'utiliser plus d'espace voici un exemple du changement sur un écran en 1920x1080

Avant : 

<img width="1908" height="914" alt="Capture d’écran 2026-04-16 à 11 18 35" src="https://github.com/user-attachments/assets/def9e163-f7a4-4b5d-bd7f-e00631e59da2" />

Après : 

<img width="1906" height="918" alt="Capture d’écran 2026-04-16 à 11 19 26" src="https://github.com/user-attachments/assets/09a656fa-07f7-4e53-b808-136bc63488ae" />

