### PR TITLE
fix(sentry): safe navigation sur confirmed_at dans WebhookController

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -135,7 +135,7 @@ les composant suivants sont affectés : #{params["components"].map { _1['name'] 
 
     [
       "Créé le: #{user.created_at.strftime("%d/%m/%Y à %H:%M").presence || 'indéfini'}",
-      "Confirmé le: #{user.confirmed_at.strftime("%d/%m/%Y à %H:%M").presence || 'indéfini'}",
+      "Confirmé le: #{user.confirmed_at&.strftime("%d/%m/%Y à %H:%M").presence || 'indéfini'}",
       "Drnr. connexion le: #{user.last_sign_in_at&.strftime("%d/%m/%Y à %H:%M").presence || 'indéfini'}",
       *dossiers,
       *html_mails


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-355
Occurrences (24h) : 1
Environnement : production

## Analyse
Dans `WebhookController#attributes`, `user.confirmed_at` peut être nil (utilisateur non confirmé). L'appel direct à `.strftime` sans safe navigation lève un `NoMethodError`. La ligne suivante (`last_sign_in_at`) utilise déjà correctement `&.strftime`.

## Fix
Ajout du safe navigation operator `&.` sur `user.confirmed_at` à la ligne 138 de `app/controllers/webhook_controller.rb`.

## Test plan
- [ ] CI verte
- [ ] Vérification manuelle par un humain
- [ ] Aucun impact sur les spécificités PF (aucun tag # pf: touché)

---
🤖 PR générée automatiquement par claude sentry-triage