### PR TITLE
fix(rebase): écriture système des formules en main sur dossier en_construction

### DIFF
--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -415,8 +415,12 @@ module DossierChampsConcern
     attributes.merge(id: champ.id, updated_by:)
   end
 
-  def champ_upsert_by!(type_de_champ, row_id)
-    check_valid_stream_on_write?(type_de_champ)
+  # pf: system_write: true → bypass du check stream pour les écritures
+  # système (ex: rebase qui matérialise une formule publique en main alors
+  # que le dossier est en_construction). Les écritures déclenchées par une
+  # action user/instructeur doivent toujours laisser le check actif.
+  def champ_upsert_by!(type_de_champ, row_id, system_write: false)
+    check_valid_stream_on_write?(type_de_champ) unless system_write
     check_valid_row_id_on_write?(type_de_champ, row_id)
 
     # FIXME: This is a temporary on-demand migration. It will be removed once the full migration is over.

--- a/app/models/concerns/dossier_formula_refresh_concern.rb
+++ b/app/models/concerns/dossier_formula_refresh_concern.rb
@@ -81,7 +81,7 @@ module DossierFormulaRefreshConcern
   # Retourne : le hash overrides complet { stable_id => value } incluant
   # les valeurs initiales et toutes les formules calculées. Permet à
   # l'appelant d'enchaîner sans réinterroger la BDD.
-  def compute_formulas_in_order(seed_overrides: {}, only: nil, persist: true, create_missing: true, row_id: nil)
+  def compute_formulas_in_order(seed_overrides: {}, only: nil, persist: true, create_missing: true, row_id: nil, system_write: false)
     formula_tdcs = revision.types_de_champ.filter(&:formule?)
     formula_tdcs = formula_tdcs.filter { |tdc| only.include?(tdc.stable_id) } if only
     return seed_overrides.dup if formula_tdcs.empty?
@@ -113,7 +113,7 @@ module DossierFormulaRefreshConcern
           next unless create_missing
           target = Dossier.no_touching do
             with_champ_stream(formule_champ) do
-              send(:champ_upsert_by!, tdc, formule_champ.row_id)
+              send(:champ_upsert_by!, tdc, formule_champ.row_id, system_write: system_write)
             end
           end
           if target.read_attribute(:value) != new_value

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -65,6 +65,14 @@ module DossierRebaseConcern
     # target_revision pour que compute_formulas_in_order itère bien sur la
     # nouvelle révision.
     self.revision = target_revision
-    compute_formulas_in_order
+    # pf: rebase = écriture système. On force le stream main (la version
+    # officielle de la formule, indépendante du buffer usager) et on passe
+    # system_write: true pour bypasser check_valid_stream_on_write?, qui
+    # interdirait sinon l'écriture main sur un dossier en_construction
+    # (cas d'une formule publique ajoutée pendant que des dossiers sont
+    # en cours de remplissage).
+    with_main_stream do
+      compute_formulas_in_order(system_write: true)
+    end
   end
 end

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -429,9 +429,6 @@ describe DossierRebaseConcern do
       # pf: quand un champ formule est ajouté dans une nouvelle révision, le
       # rebase doit créer le champ en BDD avec sa valeur calculée pour que
       # les tableaux instructeur l'affichent correctement.
-      # pf: quand un champ formule est ajouté dans une nouvelle révision, le
-      # rebase doit créer le champ en BDD avec sa valeur calculée pour que
-      # les tableaux instructeur l'affichent correctement.
       context 'when a formule tdc is added' do
         before do
           # Étape 1 : ajouter un champ Montant et publier
@@ -468,6 +465,33 @@ describe DossierRebaseConcern do
           expect(formule_champ).to be_present
           expect(formule_champ).to be_persisted
           expect(formule_champ.value).to eq('200')
+        end
+
+        # pf: cas qui faisait planter le rebase avec
+        # 'Can not write to "main" stream on a dossier "en construction"'
+        # avant le fix (système d'écriture stream main bypassée par
+        # system_write: true).
+        context 'on a dossier en_construction' do
+          before do
+            dossier.passer_en_construction!
+            dossier.reload
+          end
+
+          it 'creates the formule champ in main stream with its computed value' do
+            procedure.publish_revision!(procedure.administrateurs.first)
+            dossier.reload
+            expect { dossier.rebase! }.not_to raise_error
+            dossier.reload
+
+            formule_champ = dossier.champs.find { _1.libelle == 'Double' && _1.stream == Champ::MAIN_STREAM }
+            expect(formule_champ).to be_present
+            expect(formule_champ).to be_persisted
+            expect(formule_champ.value).to eq('200')
+
+            # pas de pollution du user_buffer
+            expect(Champ.where(dossier_id: dossier.id, stream: Champ::USER_BUFFER_STREAM,
+                               stable_id: formule_champ.stable_id)).to be_empty
+          end
         end
       end
 


### PR DESCRIPTION
## Contexte

Le rebase d'un dossier \`en_construction\` qui ajoute un champ formule public plante avec :

\`\`\`
Can not write to "main" stream on a dossier "en construction"
   from app/models/concerns/dossier_champs_concern.rb:484:in 'check_valid_stream_on_write?'
\`\`\`

\`compute_formulas_in_order\` appelle \`champ_upsert_by!\` pour matérialiser la formule, mais cet appel hérite du \`@stream\` par défaut (\`main\`) hors d'un contexte de contrôleur — et le check stream interdit toute écriture main pendant \`en_construction\` (l'usager travaille sur \`user_buffer\`).

Or \`champ_upsert_by!\` est la primitive d'écriture **utilisateur**. Le rebase est une écriture **système** : il consolide la version officielle du dossier indépendamment du buffer usager.

## Décisions

- Une formule consolidée vit en \`main\`. Le \`user_buffer\` reste réservé aux previews côté usager (recalcul cascade pendant qu'il édite une source) — ce comportement est inchangé.
- Le rebase = écriture système → bypass légitime du check stream.

## Fix

1. \`champ_upsert_by!\` : ajout d'un kwarg \`system_write: false\`. Quand \`true\`, le check stream est bypassé. Comportement inchangé pour tous les appels existants (\`champ_for_update\`, \`public_champ_for_update\`, \`private_champ_for_update\`).
2. \`compute_formulas_in_order\` : kwarg \`system_write:\` propagé jusqu'à \`champ_upsert_by!\` (uniquement dans la branche création).
3. \`rebase\` : \`compute_formulas_in_order\` est wrappé dans \`with_main_stream\` et appelé avec \`system_write: true\`.

## Cas couverts

| Contexte | Stream | Résultat |
|---|---|---|
| Édition usager en construction modifie une source | \`user_buffer\` | recalcul cascade en buffer (inchangé) |
| Édition instructeur sur annotation privée source | \`main\` | recalcul cascade en main (inchangé) |
| Rebase dossier \`en_construction\` avec ajout formule publique | \`main\` | **fix** — matérialisation en main, bypass autorisé |
| Rebase dossier \`en_instruction\` avec ajout formule | \`main\` | matérialisation en main (inchangé) |

## Tests

- Nouveau test dans \`spec/models/concerns/dossier_rebase_concern_spec.rb\` : rebase d'un dossier \`en_construction\` avec ajout d'une formule publique. Vérifie que le champ est créé en \`main\`, calculé, et qu'aucun \`user_buffer\` n'est pollué.
- \`bundle exec rspec spec/models/concerns/dossier_rebase_concern_spec.rb spec/models/concerns/dossier_formula_refresh_concern_spec.rb spec/models/concerns/dossier_champs_concern_spec.rb\` → 92/92 ✅

## Test plan

- [ ] Sur env de pré-prod, prendre un dossier \`en_construction\` rattaché à une procédure dont la révision publiée a des formules ajoutées non encore matérialisées
- [ ] Vérifier \`d.rebase!\` ne plante pas
- [ ] Vérifier que les champs formules sont créés en \`main\` avec la valeur calculée
- [ ] Vérifier que l'instructeur les voit dans la liste des dossiers sans intervention de l'usager
- [ ] Vérifier qu'un usager qui édite ensuite une source voit bien sa formule recalculée en preview (user_buffer) — non-régression

🤖 Generated with [Claude Code](https://claude.com/claude-code)