### PR TITLE
feat(grid): largeur adaptative des PJ + saut de ligne automatique

### DIFF
--- a/app/assets/stylesheets/champs_grid.scss
+++ b/app/assets/stylesheets/champs_grid.scss
@@ -22,16 +22,21 @@
     &.champ-grid-item--half {
       grid-column: span 6;
     }
-    // pf: TEST taxonomie A — quarter passe à span 4 (1/3) pour évaluer la viabilité d'une grille tiers. Revert = span 3.
-    &.champ-grid-item--quarter {
+    &.champ-grid-item--third {
       grid-column: span 4;
+    }
+
+    // pf: force le retour à la ligne avant ce champ pour grouper les PJ mono-fichier
+    // entre elles (cf. champ_break_before_class dans InstructeurChampDisplayHelper).
+    &.champ-grid-item--break-before {
+      grid-column-start: 1;
     }
   }
 
-  // tablette (62em–80em) : half reste en half, quarter se regroupe par 2
+  // tablette (62em–80em) : half reste en half, third se regroupe par 2
   @media (min-width: 62em) and (max-width: 80em) {
     .champ-grid-item {
-      &.champ-grid-item--quarter {
+      &.champ-grid-item--third {
         grid-column: span 6;
       }
     }

--- a/app/assets/stylesheets/champs_grid.scss
+++ b/app/assets/stylesheets/champs_grid.scss
@@ -10,20 +10,23 @@
   row-gap: 0;
 
   .champ-grid-item {
-    grid-column: span 12; // safe default
+    // pf: on utilise grid-column-end (longhand) plutôt que grid-column (shorthand)
+    // pour que la classe --break-before, qui ne touche que grid-column-start, ne
+    // réinitialise pas l'end à auto et donc ne réduise pas l'item à 1 colonne.
+    grid-column-end: span 12; // safe default
 
     // liseret discret bas : sépare visuellement les champs adjacents
     border-bottom: 1px solid var(--border-default-grey);
     padding: 0.25rem 0;
 
     &.champ-grid-item--full {
-      grid-column: span 12;
+      grid-column-end: span 12;
     }
     &.champ-grid-item--half {
-      grid-column: span 6;
+      grid-column-end: span 6;
     }
     &.champ-grid-item--third {
-      grid-column: span 4;
+      grid-column-end: span 4;
     }
 
     // pf: force le retour à la ligne avant ce champ pour grouper les PJ mono-fichier
@@ -37,7 +40,7 @@
   @media (min-width: 62em) and (max-width: 80em) {
     .champ-grid-item {
       &.champ-grid-item--third {
-        grid-column: span 6;
+        grid-column-end: span 6;
       }
     }
   }
@@ -91,6 +94,35 @@
   // Neutralise le float: right global de demande.scss pour ne pas casser la nouvelle position.
   .champ-row .champ-updated {
     float: none;
+  }
+
+  // pf: PJ multi en pleine largeur (--full) — étaler les fichiers en grille
+  // alignée sur les colonnes de la grille parente, à chaque breakpoint :
+  // - desktop : 3 cols (= 3 --third adjacentes)
+  // - tablette (62-80em) : 2 cols (--third passe à span 6 à ce breakpoint)
+  // - mobile (<62em) : 1 col (grille externe en mono-colonne)
+  // Les thumbnails tombent pile sous une éventuelle rangée de --third
+  // au-dessus, préservant le rythme visuel.
+  // Note : les @media sont nestées dans le bloc pour gagner sur la cascade
+  // (ordre source) face à la règle de base ci-dessous.
+  .champ-grid-item--full .gallery-items-list {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+
+    // override du width: 100% de la classe utilitaire .width-100 ; la cellule
+    // grid contraint déjà la largeur.
+    > .flex.width-100 {
+      width: auto;
+    }
+
+    @media (min-width: 62em) and (max-width: 80em) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    @media (max-width: 62em) {
+      grid-template-columns: 1fr;
+    }
   }
 
   // pf: bouton "cliquer pour copier" — on réserve l'espace en continu pour éviter

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
@@ -3,6 +3,7 @@
 - instructeur = controller.respond_to?(:current_instructeur) ? current_instructeur : nil
 - force_stacked = profile == 'instructeur' && (!helpers.dossier_layout_grid_enabled?(instructeur) || helpers.instructeur_champs_layout_mode(instructeur) == :stacked)
 .champs-grid{ class: (force_stacked ? 'champs-grid--stacked' : nil) }
+  - previous_champ = nil
   - each_champ do |champ|
     - if champ.repetition?
       .champ-grid-item.champ-grid-item--full
@@ -13,7 +14,7 @@
             = render ViewableChamp::SectionComponent.new(dossier: champ.dossier, types_de_champ:, row_id:, demande_seen_at: seen_at, profile:)
 
     - else
-      %div{ class: "champ-grid-item #{helpers.champ_display_width_class(champ)}" }
+      %div{ class: ["champ-grid-item", helpers.champ_display_width_class(champ), helpers.champ_break_before_class(champ, previous_champ)].compact.join(' ') }
         = render Dossiers::RowShowComponent.new(label: champ.libelle, seen_at:, profile:, content_class: champ.type_champ, updated_at: updated_at_after_deposer(champ)) do |c|
           - if champ.blank?
             - c.with_blank do
@@ -86,3 +87,4 @@
               - else
                 .copy-zone{ 'data-to-copy': champ.to_s.strip }
                   = helpers.format_text_value(champ.to_s.strip)
+    - previous_champ = champ

--- a/app/helpers/instructeur_champ_display_helper.rb
+++ b/app/helpers/instructeur_champ_display_helper.rb
@@ -24,22 +24,53 @@ module InstructeurChampDisplayHelper
     te_fenua: :full,
     engagement_juridique: :full,
     formule: :full,
-    piece_justificative: :full,
     titre_identite: :full,
     # half : contenu de taille moyenne
     siret: :half,
     iban: :half,
     address: :half,
     multiple_drop_down_list: :half
-    # default = :quarter pour tout le reste
+    # default = :third pour tout le reste
+    # piece_justificative et titre_identite : largeur calculée au runtime selon le nombre de fichiers
   }.freeze
 
+  # pf: 95% des champs PJ ne contiennent qu'un seul fichier (mesure prod 2026-04).
+  # Pour ce cas dominant, on préfère 1/3 (3 par rangée, thumbnail 200px confortable).
+  # À partir de 2 fichiers, on bascule en pleine largeur pour laisser respirer la galerie.
   def champ_display_width(champ)
-    TYPE_CHAMP_TO_DISPLAY_WIDTH.fetch(champ.type_champ.to_sym, :quarter)
+    if pj_attachment_champ?(champ)
+      pj_mono_file?(champ) ? :third : :full
+    else
+      TYPE_CHAMP_TO_DISPLAY_WIDTH.fetch(champ.type_champ.to_sym, :third)
+    end
   end
 
   def champ_display_width_class(champ)
     "champ-grid-item--#{champ_display_width(champ)}"
+  end
+
+  # pf: une PJ mono-fichier (largeur 1/3) doit former une rangée homogène avec ses voisines
+  # PJ-mono pour ne pas se mélanger à des champs courts qui décaleraient sa hauteur.
+  # → break-before quand on bascule entre "PJ-mono" et "non-PJ-mono".
+  # Les PJ multi-fichiers passent en :full et cassent la rangée nativement, donc traitées
+  # comme non-PJ-mono dans cette règle.
+  def champ_break_before_class(champ, previous_champ)
+    return nil if previous_champ.nil?
+    return nil if pj_mono_for_grouping?(champ) == pj_mono_for_grouping?(previous_champ)
+
+    'champ-grid-item--break-before'
+  end
+
+  def pj_attachment_champ?(champ)
+    champ.piece_justificative? || champ.titre_identite?
+  end
+
+  def pj_mono_file?(champ)
+    champ.piece_justificative_file.attachments.size <= 1
+  end
+
+  def pj_mono_for_grouping?(champ)
+    pj_attachment_champ?(champ) && pj_mono_file?(champ)
   end
 
   def instructeur_champs_layout_mode(instructeur = nil)

--- a/spec/helpers/instructeur_champ_display_helper_spec.rb
+++ b/spec/helpers/instructeur_champ_display_helper_spec.rb
@@ -4,6 +4,106 @@ describe InstructeurChampDisplayHelper do
   let(:instructeur) { create(:instructeur) }
   let(:user) { instructeur.user }
 
+  def fake_pj_champ(attachments_count:, type: :piece_justificative)
+    attachments = double('attachments', size: attachments_count)
+    pjf = double('piece_justificative_file', attachments: attachments)
+    double(
+      'champ',
+      type_champ: type.to_s,
+      piece_justificative?: type == :piece_justificative,
+      titre_identite?: type == :titre_identite,
+      piece_justificative_file: pjf
+    )
+  end
+
+  def fake_other_champ(type)
+    double(
+      'champ',
+      type_champ: type.to_s,
+      piece_justificative?: false,
+      titre_identite?: false
+    )
+  end
+
+  describe '#champ_display_width' do
+    it 'PJ avec 1 fichier → :third' do
+      expect(helper.champ_display_width(fake_pj_champ(attachments_count: 1))).to eq(:third)
+    end
+
+    it 'PJ avec 0 fichier (champ vide) → :third' do
+      expect(helper.champ_display_width(fake_pj_champ(attachments_count: 0))).to eq(:third)
+    end
+
+    it 'PJ avec 2 fichiers → :full' do
+      expect(helper.champ_display_width(fake_pj_champ(attachments_count: 2))).to eq(:full)
+    end
+
+    it 'PJ avec 5 fichiers → :full' do
+      expect(helper.champ_display_width(fake_pj_champ(attachments_count: 5))).to eq(:full)
+    end
+
+    it 'titre_identite mono-fichier → :third' do
+      expect(helper.champ_display_width(fake_pj_champ(attachments_count: 1, type: :titre_identite))).to eq(:third)
+    end
+
+    it 'titre_identite multi-fichier → :full' do
+      expect(helper.champ_display_width(fake_pj_champ(attachments_count: 2, type: :titre_identite))).to eq(:full)
+    end
+
+    it 'header_section → :full' do
+      expect(helper.champ_display_width(fake_other_champ(:header_section))).to eq(:full)
+    end
+
+    it 'siret → :half' do
+      expect(helper.champ_display_width(fake_other_champ(:siret))).to eq(:half)
+    end
+
+    it 'text (default) → :third' do
+      expect(helper.champ_display_width(fake_other_champ(:text))).to eq(:third)
+    end
+  end
+
+  describe '#champ_break_before_class' do
+    let(:pj_mono)         { fake_pj_champ(attachments_count: 1) }
+    let(:pj_mono_other)   { fake_pj_champ(attachments_count: 1) }
+    let(:ti_mono)         { fake_pj_champ(attachments_count: 1, type: :titre_identite) }
+    let(:pj_multi)        { fake_pj_champ(attachments_count: 3) }
+    let(:text_champ)      { fake_other_champ(:text) }
+    let(:header_champ)    { fake_other_champ(:header_section) }
+
+    it 'pas de previous → nil (premier champ)' do
+      expect(helper.champ_break_before_class(pj_mono, nil)).to be_nil
+    end
+
+    it 'PJ-mono après champ texte → break-before' do
+      expect(helper.champ_break_before_class(pj_mono, text_champ)).to eq('champ-grid-item--break-before')
+    end
+
+    it 'PJ-mono après PJ-mono → nil (groupées)' do
+      expect(helper.champ_break_before_class(pj_mono, pj_mono_other)).to be_nil
+    end
+
+    it 'titre_identite-mono après PJ-mono → nil (groupées entre attachments)' do
+      expect(helper.champ_break_before_class(ti_mono, pj_mono)).to be_nil
+    end
+
+    it 'champ texte après PJ-mono → break-before' do
+      expect(helper.champ_break_before_class(text_champ, pj_mono)).to eq('champ-grid-item--break-before')
+    end
+
+    it 'PJ-multi (full) après PJ-mono → break-before' do
+      expect(helper.champ_break_before_class(pj_multi, pj_mono)).to eq('champ-grid-item--break-before')
+    end
+
+    it 'PJ-mono après PJ-multi → break-before' do
+      expect(helper.champ_break_before_class(pj_mono, pj_multi)).to eq('champ-grid-item--break-before')
+    end
+
+    it 'header (full) après texte → nil (transition non-pj-mono → non-pj-mono)' do
+      expect(helper.champ_break_before_class(header_champ, text_champ)).to be_nil
+    end
+  end
+
   describe '#dossier_layout_grid_enabled?' do
     subject { helper.dossier_layout_grid_enabled?(instructeur) }
 


### PR DESCRIPTION
## Contexte

Sur l'affichage du dossier instructeur (feature grid), les champs **pièce justificative** étaient en pleine largeur pour accommoder la preview de 200px. Conséquences :
- Quand 4 PJ se suivaient, le rendu repassait visuellement en mode colonne — l'effet recherché par la grille était perdu
- Quand une PJ était mélangée avec des champs courts (nombre, texte), sa hauteur cassait l'alignement de la rangée

## Approche : largeur adaptative selon le nombre de fichiers

Mesure prod (avril 2026, ~210k champs PJ avec ≥1 fichier) :

| Fichiers | Champs | % |
|---|---|---|
| 1 | 199 099 | **94.64%** |
| 2 | 6 730 | 3.20% |
| 3+ | 4 558 | 2.16% |

→ Le cas dominant est très majoritaire. On l'optimise différemment du cas multi-fichiers :

- **PJ mono-fichier** → `:third` (3 par rangée, thumbnail 200px confortable)
- **PJ multi-fichiers** → `:full` (la galerie wrappe naturellement en flex)

## Règle de saut de ligne automatique

Une PJ mono-fichier reste plus haute qu'un champ texte. Pour éviter qu'une PJ isolée déforme une rangée de champs courts, on force un **retour à la ligne** quand on passe d'un champ "PJ-mono" à un champ "non-PJ-mono" (ou inversement).

Effet visuel :
- 3 PJ mono à la suite → rangée homogène de 3 thumbnails
- 1 PJ mono entourée de champs courts → la PJ casse la rangée et démarre seule
- Mélange `[texte, nombre, PJ-mono, PJ-mono, nombre]` → `[texte, nombre]` rangée 1, `[PJ, PJ]` rangée 2, `[nombre]` rangée 3

Les PJ multi-fichiers passent en `:full` et cassent la rangée nativement (donc traitées comme "non-PJ-mono" dans la règle de groupement).

## Détails techniques

- Largeur calculée au runtime dans `InstructeurChampDisplayHelper#champ_display_width` selon `champ.piece_justificative_file.attachments.size`
- Nettoyage de la taxonomie : `:quarter` (qui valait span 4 = 1/3, marqué "TEST taxonomie A") renommé proprement en `:third`
- Nouvelle classe CSS `.champ-grid-item--break-before { grid-column-start: 1 }`
- Tracking de `previous_champ` dans la boucle de `champs_rows_show_component` ; la récursivité dans les répétitions est gratuite (le sub-render appelle le même component avec son propre tracking)

## Tests

- 17 nouveaux specs sur le helper (largeur runtime + règle de break-before)
- Pas de test system : la logique est unitaire et la règle "un bug ici serait tolérable" justifie de rester simple

## Validation manuelle attendue

- [ ] Vérifier visuellement sur un dossier avec mélange de champs courts et de PJ
- [ ] Vérifier le cas PJ multi-fichiers (galerie en pleine largeur)
- [ ] Vérifier dans une répétition

🤖 Generated with [Claude Code](https://claude.com/claude-code)