### PR TITLE
fix(sentry): corrige ArgumentError dans format_in_2_columns pour génération PDF dossier

### DIFF
--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -30,10 +30,14 @@ def format_in_2_lines(pdf, champ, nb_lines = 1)
   pdf.text "\n"
 end
 
-def format_in_2_columns(pdf, label)
+def format_in_2_columns(pdf, label, value = nil)
   pdf.text_box label, width: 200, height: 100, overflow: :expand, at: [0, pdf.cursor]
-  pdf.bounding_box([110, pdf.cursor + 5], :width => 350, :height => 20) do
-    pdf.stroke_bounds
+  if value.present?
+    render_expanding_text_box(pdf, value, width: 350, height: 100, at: [110, pdf.cursor])
+  else
+    pdf.bounding_box([110, pdf.cursor + 5], :width => 350, :height => 20) do
+      pdf.stroke_bounds
+    end
   end
 
   pdf.text "\n"


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-35Z
Occurrences (24h) : 1
Environnement : production

## Analyse
L'appel `format_in_2_columns(pdf, 'Dossier n°', @dossier.id.to_s)` dans `app/views/dossiers/show.pdf.prawn:354` passe 3 arguments, mais la définition dans `app/views/dossiers/dossier_vide.pdf.prawn` n'en accepte que 2.

Bien que `show.pdf.prawn` définisse sa propre version de `format_in_2_columns` à 3 paramètres (ligne 61), les méthodes des templates Prawn sont définies dans la même portée globale d'`ActionView::Base`. Lorsque les deux templates sont chargés en mémoire (cas typique en production avec template caching), la définition à 2 paramètres de `dossier_vide.pdf.prawn` peut écraser celle de `show.pdf.prawn`, provoquant l'erreur `ArgumentError: wrong number of arguments (given 3, expected 2)` lors d'un GET sur `/dossiers/:id.pdf`.

## Fix
Mise à jour de la signature de `format_in_2_columns` dans `app/views/dossiers/dossier_vide.pdf.prawn` pour accepter un troisième paramètre optionnel `value` (par défaut `nil`).

- Si `value` est fourni : la valeur est rendue dans la zone de droite via `render_expanding_text_box` (cohérent avec `render_in_2_columns` du même fichier).
- Si `value` est absent (cas du dossier vide) : on conserve le comportement existant qui dessine une zone vide à remplir manuellement.

Cela rend les deux définitions compatibles entre elles (3 args), et préserve les ~10 appels existants dans `dossier_vide.pdf.prawn` qui n'utilisent que 2 args.

Fichiers modifiés :
- `app/views/dossiers/dossier_vide.pdf.prawn`

## Test plan
- [ ] CI verte
- [ ] Vérification manuelle par un humain (générer un PDF de dossier)
- [ ] Aucun impact sur les spécificités PF (aucun tag # pf: touché)

---
🤖 PR générée automatiquement par claude sentry-triage