### PR TITLE
fix(sentry): traduire Aws::S3::Errors::NotFound en ActiveStorage::FileNotFoundError

### DIFF
--- a/app/lib/active_storage/virus_scanner.rb
+++ b/app/lib/active_storage/virus_scanner.rb
@@ -44,6 +44,8 @@ class ActiveStorage::VirusScanner
         { virus_scan_result: INFECTED, virus_scanned_at: Time.zone.now }
       end
     end
+  rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
+    { virus_scan_result: INTEGRITY_ERROR, virus_scanned_at: Time.zone.now }
   end
 
   private

--- a/app/lib/active_storage/virus_scanner.rb
+++ b/app/lib/active_storage/virus_scanner.rb
@@ -45,7 +45,12 @@ class ActiveStorage::VirusScanner
       end
     end
   rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
-    { virus_scan_result: INTEGRITY_ERROR, virus_scanned_at: Time.zone.now }
+    # Le blob a été supprimé du backend S3 entre la mise en queue du job et son
+    # exécution. On traduit en ActiveStorage::FileNotFoundError pour que le job
+    # le discard (cohérent avec `discard_on ActiveStorage::FileNotFoundError`
+    # dans VirusScannerJob) au lieu de marquer le blob INTEGRITY_ERROR, qui
+    # afficherait un faux message "fichier corrompu" en UI.
+    raise ActiveStorage::FileNotFoundError
   end
 
   private

--- a/spec/jobs/virus_scanner_job_spec.rb
+++ b/spec/jobs/virus_scanner_job_spec.rb
@@ -62,4 +62,15 @@ describe VirusScannerJob, type: :job do
       expect { subject }.not_to raise_error
     end
   end
+
+  context "when the file is missing from the S3 backend (race with deletion)" do
+    before do
+      allow(blob).to receive(:open).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+    end
+
+    it "discards the job without marking the blob as corrupt" do
+      expect { subject }.not_to raise_error
+      expect(blob.reload.virus_scanner.corrupt?).to be_falsy
+    end
+  end
 end


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-33S
Occurrences (total) : 2
Environnement : production

## Analyse

Race condition : quand un blob ActiveStorage est supprimé du backend S3 après la mise en queue de `VirusScannerJob` mais avant son exécution, l'appel `blob.open` lève `Aws::S3::Errors::NotFound` (exception bas niveau de l'SDK AWS).

`VirusScannerJob` déclare déjà :
```ruby
discard_on ActiveStorage::FileNotFoundError
```
pour traiter ce cas, mais ActiveStorage ne convertit pas systématiquement les erreurs S3 brutes en `FileNotFoundError` → l'exception remonte et fait échouer le job.

## Fix

Dans `ActiveStorage::VirusScanner#attributes`, on rescue `Aws::S3::Errors::NotFound` et `NoSuchKey` et on les **traduit en `ActiveStorage::FileNotFoundError`**, ce qui permet au `discard_on` du job de prendre le relais — cohérent avec l'intention déjà codée.

### Pourquoi pas marquer `INTEGRITY_ERROR` (version initiale de la PR) ?

L'approche initiale marquait le blob comme `INTEGRITY_ERROR`, mais c'est sémantiquement incorrect :
- **`INTEGRITY_ERROR` = fichier corrompu** (cas vraiment géré dans le job via `retry_on ActiveStorage::IntegrityError`)
- **Fichier supprimé = absence**, pas corruption

Conséquence pratique : les composants `Attachment::ShowComponent` et `Attachment::EditComponent` testent `attachment.virus_scanner.corrupt?` et affichent "Le fichier est corrompu" si vrai. Marquer un fichier absent comme corrompu produirait un message UI trompeur.

## Test plan

- [x] Spec dédiée (`when the file is missing from the S3 backend (race with deletion)`)
- [x] CI verte
- [x] Branche à jour avec devpf
- [ ] Vérification manuelle par un humain
- [ ] Aucun impact sur les spécificités PF (aucun tag `# pf:` touché)

---
🤖 PR initialement générée par claude sentry-triage ; refactorisée suite à revue.
