### PR TITLE
fix(lexpol): match Arrêté en CM/PR (et pas seulement "Arrêté" strict)

### DIFF
--- a/app/services/lexpol_service.rb
+++ b/app/services/lexpol_service.rb
@@ -123,11 +123,13 @@ class LexpolService
     champ.lexpol_dossier_url = dossier_info['lienDossier'] if dossier_info['lienDossier'].present?
 
     # pf: Chercher le lien arrêté publié au JOPF (lienLexpol)
-    # Le lien est dans l'élément de type "Arrêté"
+    # Lexpol renvoie typeElement préfixé par "Arrêté" : "Arrêté en CM", "Arrêté en PR", etc.
     # Note: lienBC et lienElement nécessitent une authentification agent, donc inutiles pour l'email usager
     # Une fois présent, ce lien est immuable (publication JOPF définitive)
-    arrete_element = dossier_info['elements']&.find { |el| el['typeElement'] == 'Arrêté' }
-    if arrete_element && arrete_element['lienLexpol'].present?
+    arrete_element = dossier_info['elements']&.find do |el|
+      el['typeElement'].to_s.start_with?('Arrêté') && el['lienLexpol'].present?
+    end
+    if arrete_element
       champ.lexpol_arrete_lien = arrete_element['lienLexpol']
     end
 

--- a/spec/jobs/refresh_lexpol_champ_job_spec.rb
+++ b/spec/jobs/refresh_lexpol_champ_job_spec.rb
@@ -36,20 +36,48 @@ RSpec.describe RefreshLexpolChampJob, type: :job do
     end
 
     context 'when first instructeur has access' do
-      it 'refreshes Lexpol data with first instructeur' do
+      it 'refreshes Lexpol data with first instructeur (Arrêté en CM)' do
         allow_any_instance_of(APILexpol).to receive(:get_dossier_infos).and_return({
           'statut_libelle' => 'Enregistré par le BC',
           'lienDossier' => 'https://lexpol.cloud.pf/dossier/TEST123456',
           'elements' => [
-            { 'typeElement' => 'Arrêté', 'lienLexpol' => 'https://lexpol.cloud.pf/jopf/2025/001' },
-          ],
+            { 'typeElement' => 'Rapport de présentation en CM', 'lienLexpol' => nil },
+            { 'typeElement' => 'Arrêté en CM', 'lienLexpol' => 'http://lexpol.cloud.pf/LexpolAfficheTexte.php?ge&texte=1038589' },
+            { 'typeElement' => 'Note de présentation', 'lienLexpol' => nil }
+          ]
         })
 
         expect {
           described_class.perform_now(lexpol_champ.id)
           lexpol_champ.reload
         }.to change { lexpol_champ.lexpol_status }.to('Enregistré par le BC')
-          .and change { lexpol_champ.lexpol_arrete_lien }.to('https://lexpol.cloud.pf/jopf/2025/001')
+          .and change { lexpol_champ.lexpol_arrete_lien }.to('http://lexpol.cloud.pf/LexpolAfficheTexte.php?ge&texte=1038589')
+      end
+
+      it 'matches "Arrêté en PR" too' do
+        allow_any_instance_of(APILexpol).to receive(:get_dossier_infos).and_return({
+          'statut_libelle' => 'Publié au JOPF',
+          'elements' => [
+            { 'typeElement' => 'Arrêté en PR', 'lienLexpol' => 'http://lexpol.cloud.pf/LexpolAfficheTexte.php?texte=999' }
+          ]
+        })
+
+        described_class.perform_now(lexpol_champ.id)
+        expect(lexpol_champ.reload.lexpol_arrete_lien).to eq('http://lexpol.cloud.pf/LexpolAfficheTexte.php?texte=999')
+      end
+
+      it 'ne remonte pas les éléments non-arrêtés (rapport, note, souche)' do
+        allow_any_instance_of(APILexpol).to receive(:get_dossier_infos).and_return({
+          'statut_libelle' => 'Enregistré par le BC',
+          'elements' => [
+            { 'typeElement' => 'Rapport de présentation en CM', 'lienLexpol' => 'http://example/rapport' },
+            { 'typeElement' => 'Souche(s)', 'lienLexpol' => nil },
+            { 'typeElement' => 'Note de présentation', 'lienLexpol' => 'http://example/note' }
+          ]
+        })
+
+        described_class.perform_now(lexpol_champ.id)
+        expect(lexpol_champ.reload.lexpol_arrete_lien).to be_nil
       end
     end
 

--- a/spec/jobs/refresh_lexpol_champ_job_spec.rb
+++ b/spec/jobs/refresh_lexpol_champ_job_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe RefreshLexpolChampJob, type: :job do
           'elements' => [
             { 'typeElement' => 'Rapport de présentation en CM', 'lienLexpol' => nil },
             { 'typeElement' => 'Arrêté en CM', 'lienLexpol' => 'http://lexpol.cloud.pf/LexpolAfficheTexte.php?ge&texte=1038589' },
-            { 'typeElement' => 'Note de présentation', 'lienLexpol' => nil }
-          ]
+            { 'typeElement' => 'Note de présentation', 'lienLexpol' => nil },
+          ],
         })
 
         expect {
@@ -58,8 +58,8 @@ RSpec.describe RefreshLexpolChampJob, type: :job do
         allow_any_instance_of(APILexpol).to receive(:get_dossier_infos).and_return({
           'statut_libelle' => 'Publié au JOPF',
           'elements' => [
-            { 'typeElement' => 'Arrêté en PR', 'lienLexpol' => 'http://lexpol.cloud.pf/LexpolAfficheTexte.php?texte=999' }
-          ]
+            { 'typeElement' => 'Arrêté en PR', 'lienLexpol' => 'http://lexpol.cloud.pf/LexpolAfficheTexte.php?texte=999' },
+          ],
         })
 
         described_class.perform_now(lexpol_champ.id)
@@ -72,8 +72,8 @@ RSpec.describe RefreshLexpolChampJob, type: :job do
           'elements' => [
             { 'typeElement' => 'Rapport de présentation en CM', 'lienLexpol' => 'http://example/rapport' },
             { 'typeElement' => 'Souche(s)', 'lienLexpol' => nil },
-            { 'typeElement' => 'Note de présentation', 'lienLexpol' => 'http://example/note' }
-          ]
+            { 'typeElement' => 'Note de présentation', 'lienLexpol' => 'http://example/note' },
+          ],
         })
 
         described_class.perform_now(lexpol_champ.id)


### PR DESCRIPTION
## Bug

Le champ Lexpol n'affichait jamais le lien public JOPF (`lexpol_arrete_lien`) alors que :
- l'API Lexpol renvoyait bien l'élément avec `lienLexpol` rempli
- le job de refresh tournait correctement
- les autres champs (`lexpol_status`, `lexpol_dossier_url`) étaient bien mis à jour

## Cause

`LexpolService#refresh_lexpol_data!` cherchait avec un égal strict :

```ruby
arrete_element = dossier_info['elements']&.find { |el| el['typeElement'] == 'Arrêté' }
```

Or Lexpol renvoie en réalité `typeElement = "Arrêté en CM"` (Conseil des Ministres) ou `"Arrêté en PR"` (Président). Le `find` ne matchait jamais → `lexpol_arrete_lien` jamais sauvé.

Cas réel observé sur le dossier 612561 :
```
elements: [
  { typeElement: "Rapport de présentation en CM", lienLexpol: nil },
  { typeElement: "Arrêté en CM", lienLexpol: "http://lexpol.cloud.pf/LexpolAfficheTexte.php?ge&texte=1038589" },
  ...
]
```

## Fix

Match permissif sur le préfixe `"Arrêté"` + garde sur `lienLexpol` présent (au cas où plusieurs arrêtés seraient attachés mais un seul publié au JOPF).

## Tests

- Test existant mis à jour avec un libellé réaliste (`"Arrêté en CM"`)
- Nouveau test : `"Arrêté en PR"` est aussi matché
- Nouveau test : éléments non-arrêtés (rapport, note, souche) ne sont jamais retenus, même s'ils ont un `lienLexpol`

## Backfill

Pour corriger les dossiers historiques qui sont restés muets (probablement nombreux, surtout les dossiers déjà `accepte` que le cron ne refresh plus), un script console est fourni dans le commentaire ci-dessous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)