### PR TITLE
fix(clone): cascade explicite des formules — résout MES-DEMARCHES-350

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,43 @@ Le champ `visa` utilise `accredited_users` (array d'emails) pour définir qui pe
 2. **Résolution automatique** : email → user_id au runtime  
 3. **Migration transparente** : table de mapping email ↔ user_id
 
+## Cascade des formules (recalcul après modification d'une source)
+
+**Convention : la cascade est explicite, pas implicite par callback.**
+
+Tout site qui modifie un champ source d'une formule (changement de `value`,
+`value_json`, `data`, `external_id`, `etablissement_id`, ou structurel sur
+une répétition) doit appeler explicitement :
+
+```ruby
+dossier.refresh_formulas_after(champ)
+```
+
+Sites qui doivent déclencher la cascade :
+- Controllers HTTP qui modifient un champ (`Users::DossiersController#update_dossier_and_compute_errors`, `Instructeurs::DossiersController#update_annotations`, `Champs::PieceJustificativeController`, `Champs::RNAController`)
+- Mutations GraphQL annotation (centralisée dans `Mutations::DossierModifierAnnotation#resolve_with_type`)
+- Services external_data qui changent `data`/`value_json` (`Champs::SiretChamp#update_external_data!`, `Champs::RnaChamp`, `Champs::PieceJustificativeChamp`, `Champs::ReferentielDePolynesieChamp`, `ChampExternalDataConcern`)
+- Helpers `Etablissement#update_champ_value_json!` (couvre les retours des jobs entreprise)
+- `Dossier#repetition_add_row` / `Dossier#repetition_remove_row` (formules `size(repetition)`, `count`...)
+- API entreprise : `APIEntrepriseService#create_etablissement` (via `update_champ_value_json!`)
+
+Sites qui ne déclenchent **pas** la cascade (recalcul géré autrement) :
+- `DossierCloneConcern#clone` : valeurs héritées de la source ; `rebase!` qui suit recalcule si la révision a changé.
+- `DossierRebaseConcern#rebase!` : appelle `compute_formulas_in_order` à la fin.
+- `DossierChampsConcern#merge_user_buffer_stream!` : appelle `compute_formulas_in_order(only: private_formula_stable_ids)` à la fin.
+- `DossierPrefillableConcern` + `Users::DossiersController#new_dossier` : appellent `compute_initial_formulas` après le prefill / la création.
+- Migrations / maintenance tasks : utilisent `update_all` / `update_columns` qui sautent les callbacks de toute façon.
+
+Pour le SIRET au niveau dossier (formulaire d'identité d'entreprise, pas de
+Champ source identifiable), on déclenche un recalcul global via
+`dossier.compute_formulas_in_order` (cf. `Etablissement#update_champ_value_json!`).
+
+Si tu ajoutes un nouveau flux qui modifie un champ source, **ajoute l'appel
+explicite** + une spec d'intégration qui vérifie que la formule dépendante
+est à jour. La spec de non-régression de référence est dans
+`spec/models/concerns/dossier_clone_concern_spec.rb` (context "with formula
+champs depending on a source") + `spec/models/champs/formule_cascade_audit_spec.rb`.
+
 ## Commandes utiles
 
 - Régénérer le schéma GraphQL : `bin/rails graphql:schema:dump`

--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -70,6 +70,10 @@ class Champs::PieceJustificativeController < Champs::ChampController
 
       @champ.update_timestamps
 
+      # pf: cascade explicite des formules dépendantes — remplace l'ancien
+      # callback after_save sur Champ.
+      @champ.dossier.refresh_formulas_after(@champ)
+
       dossier = DossierPreloader.load_one(@champ.dossier, pj_template: true)
       # because preloader reassigns new champ instances champs, we have to reassign it
       @champ = dossier.champs.find { it.id == @champ.id }

--- a/app/controllers/champs/rna_controller.rb
+++ b/app/controllers/champs/rna_controller.rb
@@ -7,5 +7,9 @@ class Champs::RNAController < Champs::ChampController
 
     @champ.fetch_association!(rna)
     @champ.update_timestamps
+    # pf: cascade explicite des formules dépendantes après mise à jour des
+    # données externes (data/value via fetch_association!). Le callback
+    # after_save sur saved_change_to_value? ratait les modifications de data.
+    @champ.dossier.refresh_formulas_after(@champ)
   end
 end

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -351,6 +351,10 @@ module Instructeurs
           annotation.fetch_later! if annotation.may_fetch_later?
         end
 
+        # pf: cascade explicite des formules dépendantes — remplace l'ancien
+        # callback after_save sur Champ.
+        dossier.refresh_formulas_after(annotation)
+
         dossier.index_search_terms_later
         DossierNotification.create_notification(dossier, :annotation_instructeur, except_instructeur: current_instructeur) if !dossier.brouillon?
       end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -723,6 +723,11 @@ module Users
             @update_contact_information = true
             RoutingEngine.compute(dossier)
           end
+
+          # pf: cascade explicite des formules dépendantes — remplace l'ancien
+          # callback after_save sur Champ. Le caller (ce controller) sait
+          # qu'un changement effectif a eu lieu (champ_changed).
+          dossier.refresh_formulas_after(champ)
         end
 
         if params[:validate].present? && !champ.pending?

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -483,7 +483,8 @@ module Users
       dossier.save!
       # pf: calcul initial des formules — couvre les formules constantes et
       # sur fonctions système (AUJOURDHUI, MAINTENANT). Pour les formules
-      # dépendant d'un champ usager, c'est la cascade refresh_dependent_formulas
+      # dépendant d'un champ usager, c'est l'appel explicite à
+      # dossier.refresh_formulas_after(champ) (cf. update_dossier_and_compute_errors)
       # qui prend le relais à la première édition.
       dossier.compute_initial_formulas
       # pf: notifications différées pour réduire le spam (délai basé sur estimation de remplissage)

--- a/app/graphql/mutations/dossier_modifier_annotation.rb
+++ b/app/graphql/mutations/dossier_modifier_annotation.rb
@@ -24,6 +24,11 @@ module Mutations
 
       if annotation.validate(:champs_private_value) && annotation.save
         ChampRevision.create_or_update_revision(annotation, instructeur.id)
+        # pf: cascade explicite des formules dépendantes — remplace l'ancien
+        # callback after_save sur Champ. Couvre toutes les mutations qui
+        # héritent via resolve_with_type (text, checkbox, date, decimal,
+        # integer, datetime, drop_down_list, piece_justificative).
+        dossier.refresh_formulas_after(annotation)
         { annotation: }
       else
         { errors: annotation.errors.full_messages }

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -112,8 +112,6 @@ class Champ < ApplicationRecord
   scope :public_only, -> { where(private: false) }
   scope :private_only, -> { where(private: true) }
 
-  # pf: recalcul des formules dépendantes lors de la sauvegarde d'un champ
-  after_save :refresh_dependent_formulas
   def public?
     !private?
   end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -340,8 +340,8 @@ class Champ < ApplicationRecord
   # pf: stable_ids des formules transitivement dépendantes de ce champ.
   # Pure résolution de graphe sur les types_de_champ (metadata) — n'accède
   # PAS aux champs du dossier, donc ne déclenche pas project_champs.
-  # Utilisé par la cascade refresh_dependent_formulas pour passer une liste
-  # de stable_ids à compute_formulas_in_order, qui ira chercher les Champs
+  # Utilisé par Dossier#refresh_formulas_after pour passer une liste de
+  # stable_ids à compute_formulas_in_order, qui ira chercher les Champs
   # lui-même via formule_champs_for_tdc.
   def dependent_formula_stable_ids
     formula_tdcs = dossier.revision.types_de_champ.filter(&:formule?)
@@ -401,49 +401,6 @@ class Champ < ApplicationRecord
       else
         true
       end
-    end
-  end
-
-  def refresh_dependent_formulas
-    return if stable_id.nil?
-    return if !saved_change_to_value?
-    # pf: Court-circuit rapide — si la procédure n'a aucun champ formule, rien à faire.
-    # Évite tout accès à type_de_champ / project_champs (coûteux) pour les procédures sans formule.
-    return unless dossier.revision.types_de_champ.any?(&:formule?)
-    # pf: Les champs formule eux-mêmes ne déclenchent pas de recalcul (évite les boucles)
-    return if type_de_champ.formule?
-
-    # pf: Pré-calcul des stable_ids des formules transitivement dépendantes
-    # via le graphe pur des types_de_champ — pas d'appel à project_champs
-    # (qui matérialiserait tous les Champs de la révision juste pour lire
-    # leurs stable_ids). compute_formulas_in_order ira chercher les Champs
-    # concrets ensuite via formule_champs_for_tdc.
-    #
-    # Filtre privacy : les formules privées ne peuvent être écrites que sur
-    # main (cf. check_valid_stream_on_write?). Quand la source est sur
-    # user:buffer, on skip les formules privées — elles seront recalculées au
-    # moment où les changements sont committés vers main (dépôt / instruction).
-    dependent_stable_ids = dependent_formula_stable_ids
-    if stream != Champ::MAIN_STREAM && dependent_stable_ids.any?
-      formula_tdcs_by_sid = dossier.revision.types_de_champ.filter(&:formule?).index_by(&:stable_id)
-      dependent_stable_ids = dependent_stable_ids.reject { |sid| formula_tdcs_by_sid[sid]&.private? }
-    end
-    return if dependent_stable_ids.empty?
-
-    # pf: Délégation à la méthode unique du concern. Le with_champ_stream(self)
-    # propage le stream de la source au dossier le temps de la cascade, pour
-    # que tous les upserts de champs formule créés en cascade soient sur le
-    # même stream (et que check_valid_stream_on_write? reste cohérent).
-    dossier.with_champ_stream(self) do
-      dossier.compute_formulas_in_order(
-        seed_overrides: { stable_id => value },
-        only: dependent_stable_ids,
-        # pf: propagation du row_id de la source — limite le recalcul aux
-        # Champs formule de la même row (cas répétition) + ceux hors répétition.
-        # Évite de recalculer toutes les rows alors que seule la row de la
-        # source modifiée a été affectée.
-        row_id: row_id
-      )
     end
   end
 

--- a/app/models/champs/formule_champ.rb
+++ b/app/models/champs/formule_champ.rb
@@ -11,8 +11,13 @@ class Champs::FormuleChamp < Champ
   #   1. Création du dossier : appel explicite à dossier.compute_initial_formulas
   #      depuis les controllers (Users::Dossiers#new_dossier, Commencer,
   #      Api::Public::V1, ProcedureRevision#dossier_for_preview).
-  #   2. Modification d'un champ source : Champ#after_save :refresh_dependent_formulas
-  #      → cascade via compute_formulas_in_order avec seed.
+  #   2. Modification d'un champ source : appel explicite à
+  #      dossier.refresh_formulas_after(champ) depuis les controllers HTTP
+  #      (users, instructeurs, champs/*), les mutations GraphQL (annotation*),
+  #      les services external_data (SIRET/RNA/référentiel/api_entreprise) et
+  #      les flux structurels (repetition_add_row / repetition_remove_row).
+  #      Pas de cascade implicite via callback — chaque site qui modifie une
+  #      source déclenche explicitement le recalcul (cf. CLAUDE.md).
   #   3. Affichage en révision draft (preview admin) :
   #      Dossier#project_champ → recompute en mémoire pour refléter les
   #      modifications d'expression non encore propagées aux dossiers.

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -35,6 +35,8 @@ class Champs::PieceJustificativeChamp < Champ
   # as there is no transformation to do
   def update_external_data!(data:)
     update!(value_json: data, fetch_external_data_exceptions: [])
+    # pf: cascade explicite des formules — value_json a changé.
+    dossier.refresh_formulas_after(self)
   end
 
   def ready_for_external_call?

--- a/app/models/champs/referentiel_de_polynesie_champ.rb
+++ b/app/models/champs/referentiel_de_polynesie_champ.rb
@@ -56,6 +56,10 @@ class Champs::ReferentielDePolynesieChamp < Champs::ReferentielChamp
       )
       propagate_prefill(data)
     end
+    # pf: cascade explicite des formules — data/value_json ont changé. À ce
+    # jour les formules ne lisent pas encore les colonnes des référentiels
+    # mais on prépare le terrain pour les évolutions futures.
+    dossier.refresh_formulas_after(self)
   end
 
   # pf: autocomplete utilise le flux inline (pas de job) ; exact_match utilise le job asynchrone ;

--- a/app/models/champs/rna_champ.rb
+++ b/app/models/champs/rna_champ.rb
@@ -21,6 +21,10 @@ class Champs::RNAChamp < Champ
     value_json = data.blank? ? nil : extract_value_json(data:)
     data = (data.presence)
     update_columns(data:, value_json:, value:, fetch_external_data_exceptions: [])
+    # pf: cascade explicite des formules — update_columns saute les
+    # callbacks Rails, on doit donc déclencher manuellement le recalcul
+    # des formules dépendantes.
+    dossier.refresh_formulas_after(self)
   end
 
   def identifier

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -26,6 +26,10 @@ class Champs::SiretChamp < Champ
     else
       update(etablissement: data[:etablissement], value: external_id)
     end
+    # pf: cascade explicite des formules — etablissement/external_id/value
+    # ont changé, on recalcule les formules dépendantes (le callback
+    # after_save ne couvrait que les changements de value).
+    dossier.refresh_formulas_after(self)
   end
 
   def ready_for_external_call?

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -126,15 +126,24 @@ module ChampExternalDataConcern
     # pf: store candidates and transition to :multiple_found awaiting user selection
     def update_external_data_multiple_found!(candidates)
       update!(data: { multiple_found: candidates }, fetch_external_data_exceptions: [])
+      # pf: cascade explicite des formules — data a changé (le callback
+      # after_save sur Champ ratait ce cas car saved_change_to_value? = false).
+      dossier.refresh_formulas_after(self)
       external_data_multiple_found!
     end
 
     def update_external_data!(data:)
       update!(data:, fetch_external_data_exceptions: [])
+      # pf: cascade explicite des formules — data a changé (le callback
+      # after_save sur Champ ratait ce cas car saved_change_to_value? = false).
+      dossier.refresh_formulas_after(self)
     end
 
     def after_reset_external_data(opts = {})
       update(opts.merge(data: nil, value_json: nil, fetch_external_data_exceptions: []))
+      # pf: cascade explicite des formules — data/value_json viennent d'être
+      # vidés, les formules dépendantes doivent être recalculées.
+      dossier.refresh_formulas_after(self)
     end
   end
 end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -189,6 +189,14 @@ module DossierChampsConcern
 
     row_id = ULID.generate
     champ_for_update(type_de_champ, row_id:, updated_by:)
+    # pf: cascade explicite des formules — l'ajout d'une row peut
+    # impacter une formule du genre size(bloc_repetable) ou
+    # somme(bloc_repetable.colonne). Le callback after_save sur
+    # saved_change_to_value? ne se déclenche pas (création d'un row champ
+    # vide → value nil → nil). On déclenche explicitement à partir du
+    # champ repetition parent (stable_id = celui de la repetition,
+    # row_id = nil → recalcule toutes les formules dépendantes).
+    refresh_formulas_after(project_champ(type_de_champ))
     row_id
   end
 
@@ -197,6 +205,10 @@ module DossierChampsConcern
 
     champ = champ_for_update(type_de_champ, row_id:, updated_by:)
     champ.discard!
+    # pf: cascade explicite des formules — discard! ne touche pas value
+    # donc le callback after_save ne déclenche aucun recalcul. Une formule
+    # size(bloc_repetable) doit voir le décompte mis à jour.
+    refresh_formulas_after(project_champ(type_de_champ))
   end
 
   def stable_id_in_revision?(stable_id)

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -30,7 +30,8 @@ module DossierChampsConcern
     #    rebasés avant le fix du rebase).
     #
     # Les dossiers sur révision publiée avec champ déjà persisté ne sont pas
-    # concernés : refresh_dependent_formulas garde leur valeur à jour.
+    # concernés : l'appel explicite à refresh_formulas_after par les
+    # controllers / mutations garde leur valeur à jour.
     #
     # Garde contre la récursion : FormulaCalculationService passe par
     # project_champs_*_all → project_champ pour construire sa vue du dossier.
@@ -285,10 +286,10 @@ module DossierChampsConcern
     @stream = Champ::MAIN_STREAM
 
     # pf: Recalcul des formules privées après merge. Pendant que le dossier
-    # était sur user:buffer, la cascade refresh_dependent_formulas a
-    # explicitement skippé les formules privées (cf. check_valid_stream_on_write?
-    # qui interdit l'écriture privée hors main). Maintenant que les sources
-    # promues sont sur main et que @stream est aligné, on peut les recalculer.
+    # était sur user:buffer, refresh_formulas_after a explicitement skippé
+    # les formules privées (cf. check_valid_stream_on_write? qui interdit
+    # l'écriture privée hors main). Maintenant que les sources promues sont
+    # sur main et que @stream est aligné, on peut les recalculer.
     #
     # On cible uniquement les formules privées : les formules publiques ont
     # été calculées en cascade pendant que le dossier était en buffer (sur
@@ -468,16 +469,17 @@ module DossierChampsConcern
     elsif loaded_champ.object_id != champ.object_id
       association(:champs).target = champs - [loaded_champ] + [champ]
     end
-    # pf: rattacher le Champ à self AVANT toute opération qui déclenche la
-    # cascade (clone_value_from → save! → refresh_dependent_formulas). Sinon
-    # la cascade lit champ.dossier qui pointe sur l'instance Dossier
-    # fantôme matérialisée par create_or_find_by!, et tous les Champs
-    # formule créés en cascade s'attachent à ce fantôme — invisibles pour
-    # le contrôleur qui retravaille avec self. Au 2e save (re-cascade
-    # via assign_attributes + save), self.champs ne les contient pas et
-    # create_or_find_by! ne détecte pas le doublon en BDD car la contrainte
-    # unique sur (dossier_id, stream, stable_id, row_id) ne matche pas
-    # quand row_id IS NULL → INSERT crée un doublon.
+    # pf: rattacher le Champ à self AVANT toute opération qui déclenche
+    # une cascade (clone_value_from → save! puis recalcul des formules en
+    # aval via compute_formulas_in_order). Sinon le calcul lit champ.dossier
+    # qui pointe sur l'instance Dossier fantôme matérialisée par
+    # create_or_find_by!, et tous les Champs formule créés en cascade
+    # s'attachent à ce fantôme — invisibles pour le contrôleur qui
+    # retravaille avec self. Au 2e save (re-cascade via assign_attributes +
+    # save), self.champs ne les contient pas et create_or_find_by! ne
+    # détecte pas le doublon en BDD car la contrainte unique sur
+    # (dossier_id, stream, stable_id, row_id) ne matche pas quand
+    # row_id IS NULL → INSERT crée un doublon.
     if champ.dossier.object_id != object_id
       champ.association(:dossier).target = self
     end

--- a/app/models/concerns/dossier_formula_refresh_concern.rb
+++ b/app/models/concerns/dossier_formula_refresh_concern.rb
@@ -49,6 +49,59 @@ module DossierFormulaRefreshConcern
     end
   end
 
+  # pf: Recalcule les formules dépendant d'un champ source qui vient d'être
+  # modifié. À appeler explicitement par tout site interactif qui modifie un
+  # champ source — controller usager (édition d'un champ public), controller
+  # instructeur (édition d'une annotation privée), mutations GraphQL,
+  # services external_data (SIRET, référentiels qui peuplent value_json/data).
+  #
+  # Les flux batch (clone, prefill, rebase, merge user_buffer→main) gèrent
+  # leur propre recalcul via compute_formulas_in_order et n'appellent PAS
+  # cette méthode — éviter une cascade par champ pendant un autosave de
+  # collection (cf. bug PG::UniqueViolation sur clone, MES-DEMARCHES-350).
+  #
+  # Le caller est responsable de décider qu'un changement effectif a eu lieu
+  # (sur value, value_json, data, external_id, etablissement_id). Cette
+  # méthode ne contrôle plus saved_change_to_value? — couvrir aussi les
+  # changements de data permet aux formules de réagir aux retours de webhook
+  # SIRET ou aux mises à jour de colonnes référentielles.
+  def refresh_formulas_after(champ)
+    return unless champ&.stable_id
+    # pf: Court-circuit rapide — si la révision n'a aucune formule, rien à faire.
+    return unless revision.types_de_champ.any?(&:formule?)
+    # pf: Les champs formule eux-mêmes ne déclenchent pas de recalcul (anti-boucle)
+    return if champ.type_de_champ.formule?
+
+    # pf: Pré-calcul des stable_ids transitivement dépendants via le graphe
+    # pur des types_de_champ (pas d'accès à project_champs).
+    dependent_stable_ids = champ.dependent_formula_stable_ids
+    # pf: Filtre privacy — les formules privées ne peuvent être écrites que sur
+    # main (cf. check_valid_stream_on_write?). Quand la source est sur
+    # user:buffer, on skip les formules privées : elles seront recalculées au
+    # moment où les changements sont committés vers main (dépôt / instruction).
+    if champ.stream != Champ::MAIN_STREAM && dependent_stable_ids.any?
+      formula_tdcs_by_sid = revision.types_de_champ.filter(&:formule?).index_by(&:stable_id)
+      dependent_stable_ids = dependent_stable_ids.reject { |sid| formula_tdcs_by_sid[sid]&.private? }
+    end
+    return if dependent_stable_ids.empty?
+
+    # pf: with_champ_stream propage le stream du champ source au dossier le
+    # temps de la cascade — tous les upserts de champs formule créés en
+    # cascade restent sur le même stream (cohérence avec
+    # check_valid_stream_on_write?).
+    with_champ_stream(champ) do
+      compute_formulas_in_order(
+        seed_overrides: { champ.stable_id => champ.value },
+        only: dependent_stable_ids,
+        # pf: propagation du row_id de la source — limite le recalcul aux
+        # Champs formule de la même row (cas répétition) + ceux hors
+        # répétition. Évite de recalculer toutes les rows alors que seule
+        # celle de la source modifiée a été affectée.
+        row_id: champ.row_id
+      )
+    end
+  end
+
   # pf: Méthode unique de recalcul des formules d'un dossier dans l'ordre
   # topologique. Utilise l'invariant "position TDC = ordre topologique" (cf.
   # TypesDeChamp::FormuleTypeDeChamp#forward_reference?) : itérer les TDC

--- a/app/models/concerns/dossier_formula_refresh_concern.rb
+++ b/app/models/concerns/dossier_formula_refresh_concern.rb
@@ -127,9 +127,9 @@ module DossierFormulaRefreshConcern
   #                    certaines factories de tests).
   #   row_id         : nil par défaut (= toutes les rows). Si non-nil, limite
   #                    le recalcul aux Champs formule de cette row + ceux hors
-  #                    répétition. Utilisé par la cascade refresh_dependent_formulas
-  #                    pour ne recalculer que la row de la source modifiée
-  #                    (les autres rows ne sont pas affectées par la modif).
+  #                    répétition. Utilisé par refresh_formulas_after pour ne
+  #                    recalculer que la row de la source modifiée (les autres
+  #                    rows ne sont pas affectées par la modif).
   #
   # Retourne : le hash overrides complet { stable_id => value } incluant
   # les valeurs initiales et toutes les formules calculées. Permet à
@@ -190,8 +190,9 @@ module DossierFormulaRefreshConcern
   # - formules constantes ({1 + 1}) / sur fonctions système (AUJOURDHUI())
   # - formules sur champs source préremplis (cas Commencer)
   #
-  # Pour les formules dépendant d'un champ que l'usager modifie, c'est la
-  # cascade refresh_dependent_formulas qui prend le relais.
+  # Pour les formules dépendant d'un champ que l'usager modifie, c'est l'appel
+  # explicite à refresh_formulas_after (par les controllers / mutations /
+  # services) qui prend le relais.
   def compute_initial_formulas
     return unless revision&.types_de_champ&.any?(&:formule?)
     compute_formulas_in_order

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -235,11 +235,10 @@ class Etablissement < ApplicationRecord
   def update_champ_value_json!
     if champ.present?
       champ.update!(value_json: champ_value_json)
-      # pf: cascade explicite des formules — value_json a changé. Le
-      # callback after_save :refresh_dependent_formulas a la garde
-      # saved_change_to_value? qui ratait ce cas (seul value_json change).
+      # pf: cascade explicite des formules — value_json vient de changer,
+      # déclenche le recalcul transitif des formules qui en dépendent.
       # Couvre aussi les retours des jobs entreprise (kbis, exercices...)
-      # qui rapatrient des données et appellent cette méthode.
+      # qui rapatrient des données et rappellent cette méthode.
       champ.dossier.refresh_formulas_after(champ)
     elsif dossier.present?
       # pf: SIRET au niveau dossier (formulaire d'identité d'entreprise) —

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -233,9 +233,22 @@ class Etablissement < ApplicationRecord
   end
 
   def update_champ_value_json!
-    return if champ.nil?
-
-    champ.update!(value_json: champ_value_json)
+    if champ.present?
+      champ.update!(value_json: champ_value_json)
+      # pf: cascade explicite des formules — value_json a changé. Le
+      # callback after_save :refresh_dependent_formulas a la garde
+      # saved_change_to_value? qui ratait ce cas (seul value_json change).
+      # Couvre aussi les retours des jobs entreprise (kbis, exercices...)
+      # qui rapatrient des données et appellent cette méthode.
+      champ.dossier.refresh_formulas_after(champ)
+    elsif dossier.present?
+      # pf: SIRET au niveau dossier (formulaire d'identité d'entreprise) —
+      # pas de Champ source identifiable. Une formule peut lire
+      # entreprise.raison_commerciale, etablissement.adresse, etc., qui
+      # sont résolues via dossier.etablissement. Recalcul global pour
+      # toutes les formules de la révision.
+      dossier.compute_formulas_in_order
+    end
   end
 
   def champ_value_json

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -49,13 +49,13 @@ class APIEntrepriseService
 
       if dossier_or_champ.is_a?(Champ)
         dossier_or_champ.update!(value_json: APIGeoService.parse_etablissement_address(etablissement))
-        # pf: cascade explicite des formules — value_json a changé après
-        # parsing de l'adresse de l'établissement.
-        dossier_or_champ.dossier.refresh_formulas_after(dossier_or_champ)
       end
       if siret.length > 9
         perform_later_fetch_jobs(etablissement, procedure_id, user_id)
       end
+      # pf: la cascade explicite des formules est déclenchée par
+      # Etablissement#update_champ_value_json! (couvre les deux cas Champ et
+      # Dossier-level — formules qui lisent entreprise.raison_commerciale).
       etablissement.update_champ_value_json!
       etablissement
     end
@@ -70,9 +70,8 @@ class APIEntrepriseService
 
       if dossier_or_champ.is_a?(Champ)
         dossier_or_champ.update!(value_json: APIGeoService.parse_etablissement_address(etablissement))
-        # pf: cascade explicite des formules — value_json a changé.
-        dossier_or_champ.dossier.refresh_formulas_after(dossier_or_champ)
       end
+      # pf: cascade des formules déclenchée par update_champ_value_json!
       etablissement.update_champ_value_json!
       etablissement
     end

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -49,6 +49,9 @@ class APIEntrepriseService
 
       if dossier_or_champ.is_a?(Champ)
         dossier_or_champ.update!(value_json: APIGeoService.parse_etablissement_address(etablissement))
+        # pf: cascade explicite des formules — value_json a changé après
+        # parsing de l'adresse de l'établissement.
+        dossier_or_champ.dossier.refresh_formulas_after(dossier_or_champ)
       end
       if siret.length > 9
         perform_later_fetch_jobs(etablissement, procedure_id, user_id)
@@ -67,6 +70,8 @@ class APIEntrepriseService
 
       if dossier_or_champ.is_a?(Champ)
         dossier_or_champ.update!(value_json: APIGeoService.parse_etablissement_address(etablissement))
+        # pf: cascade explicite des formules — value_json a changé.
+        dossier_or_champ.dossier.refresh_formulas_after(dossier_or_champ)
       end
       etablissement.update_champ_value_json!
       etablissement

--- a/spec/jobs/refresh_clock_dependent_formulas_dossier_job_spec.rb
+++ b/spec/jobs/refresh_clock_dependent_formulas_dossier_job_spec.rb
@@ -11,15 +11,15 @@ describe RefreshClockDependentFormulasDossierJob do
   # pf: utilise dossier.revision (pas procedure.active_revision) : les deux sont
   # deux instances Ruby distinctes de la même ligne DB, chacune mémoïsant sa
   # propre liste types_de_champ. Si on update le TDC via procedure.active_revision,
-  # le cascade refresh_dependent_formulas (qui lit dossier.revision.types_de_champ)
-  # voit l'ancienne expression et le cascade n'a pas lieu.
+  # refresh_formulas_after (qui lit dossier.revision.types_de_champ) voit
+  # l'ancienne expression et le recalcul n'a pas lieu.
   let(:revision) { dossier.revision }
   let(:date_champ) { dossier.project_champs_public[0] }
   let(:formule_champ) { dossier.project_champs_public[1] }
 
   before do
     # pf: tout le setup dans travel_to pour stubber Date.current pendant
-    # le cascade de refresh_dependent_formulas qui appelle AGE.
+    # la cascade de recalcul qui appelle AGE.
     travel_to Time.zone.local(2026, 4, 19) do
       formule_tdc = revision.types_de_champ.find(&:formule?)
       expr, _ = FormulaExpressionService.convert_to_stable_ids('AGE({Date de naissance})', revision)

--- a/spec/models/champs/formule_cascade_audit_spec.rb
+++ b/spec/models/champs/formule_cascade_audit_spec.rb
@@ -2,10 +2,12 @@
 
 require 'rails_helper'
 
-# pf: Audit de performance et de comportement de la cascade refresh_dependent_formulas
-# Ce test sert de garde-fou CI pour détecter les régressions de performance
-# et vérifier le comportement du recalcul en chaîne.
-RSpec.describe 'Formule cascade refresh_dependent_formulas', type: :model do
+# pf: Audit de performance et de comportement de la cascade explicite des
+# formules — Dossier#refresh_formulas_after, appelée par les controllers
+# (users/instructeurs/champs), les mutations GraphQL et les services
+# external_data. Ce test sert de garde-fou CI pour détecter les régressions
+# de performance et vérifier le comportement du recalcul en chaîne.
+RSpec.describe 'Formule cascade refresh_formulas_after', type: :model do
   # ------------------------------------------------------------------
   # Helpers
   # ------------------------------------------------------------------
@@ -97,7 +99,7 @@ RSpec.describe 'Formule cascade refresh_dependent_formulas', type: :model do
       set_formule_expression(dossier, quadruple_tdc, "{tdc#{double_tdc.stable_id}} * 2")
     end
 
-    it 'propage la transitivité A → B → C via propagate_formula_updates' do
+    it 'propage la transitivité A → B → C via refresh_formulas_after' do
       # Persister les champs formule pour que update_column fonctionne
       dossier.reload
       double_champ = find_champ(dossier, double_tdc)
@@ -107,6 +109,10 @@ RSpec.describe 'Formule cascade refresh_dependent_formulas', type: :model do
 
       montant = find_champ(dossier, montant_tdc)
       montant.update!(value: '10')
+      # pf: cascade explicite — c'est désormais le caller (controller,
+      # mutation, service) qui déclenche le recalcul après modification
+      # d'un champ source. Ici on simule l'appel typique d'un controller.
+      dossier.refresh_formulas_after(montant)
 
       # Vérifier que les DEUX niveaux sont recalculés en DB
       expect(double_champ.reload.read_attribute(:value)).to eq('20')
@@ -115,7 +121,10 @@ RSpec.describe 'Formule cascade refresh_dependent_formulas', type: :model do
 
     it 'ne provoque pas de cascade infinie (pas de StackOverflow)' do
       montant = find_champ(dossier, montant_tdc)
-      expect { montant.update!(value: '999') }.not_to raise_error
+      expect {
+        montant.update!(value: '999')
+        dossier.refresh_formulas_after(montant)
+      }.not_to raise_error
     end
   end
 

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -220,8 +220,8 @@ RSpec.describe DossierChampsConcern do
     end
 
     # pf: sur un dossier soumis à une révision publiée (figée), on ne force
-    # pas le recalcul : refresh_dependent_formulas a déjà fait son travail
-    # au moment du save d'une source, et la révision ne bougera plus.
+    # pas le recalcul : refresh_formulas_after a déjà fait son travail au
+    # moment de la modification d'une source, et la révision ne bougera plus.
     context 'formule field on a dossier attached to a published revision' do
       let(:procedure) do
         create(:procedure, :published, types_de_champ_public: [

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -196,5 +196,56 @@ RSpec.describe DossierCloneConcern do
         end
       end
     end
+
+    # pf: non-régression MES-DEMARCHES-350
+    # Avant le refactor « cascade explicite » : pendant cloned_dossier.save!,
+    # autosave_association itérait sur la collection champs et déclenchait
+    # le callback after_save :refresh_dependent_formulas pour chaque champ
+    # source inséré. La cascade appelait champ_upsert_by! qui faisait un
+    # save! prématuré sur le champ formule (déjà présent in-memory dans
+    # cloned_dossier.champs). Quand autosave_association arrivait à ce
+    # champ formule, il tentait un second INSERT → PG::UniqueViolation
+    # sur (dossier_id, stream, stable_id, row_id) avec row_id IS NULL.
+    context 'with formula champs depending on a source' do
+      let(:types_de_champ_public) do
+        [
+          { type: :integer_number, libelle: 'Source', stable_id: 100 },
+          { type: :formule, libelle: 'Doublé', stable_id: 101 },
+        ]
+      end
+      let(:types_de_champ_private) { [] }
+      let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
+
+      before do
+        formule_tdc = procedure.active_revision.types_de_champ.find(&:formule?)
+        expr, _ = FormulaExpressionService.convert_to_stable_ids('{Source} * 2', procedure.active_revision)
+        formule_tdc.update!(formule_expression: expr)
+
+        # Remplir le champ source pour que la formule ait une valeur calculée
+        source_champ = dossier.project_champ(dossier.revision.types_de_champ.find { _1.stable_id == 100 })
+        source_champ.update!(value: '21')
+        dossier.compute_formulas_in_order
+        dossier.reload
+      end
+
+      it 'does not create duplicate champs in the cloned dossier' do
+        cloned = dossier.clone
+        # Avant le fix : 3 INSERTs (la cascade after_save:refresh_dependent_formulas
+        # déclenchée pendant l'autosave_association faisait un save! prématuré du
+        # champ formule via champ_upsert_by!, puis autosave_association tentait un
+        # second INSERT du même champ → 1 source + 2 formules = 3 lignes).
+        # Après le fix : 2 INSERTs (1 source + 1 formule), le clone n'a plus de
+        # cascade callback parasite, les valeurs sont héritées telles quelles.
+        champs_par_stable_id = Champ.where(dossier_id: cloned.id, stream: 'main').group(:stable_id).count
+        expect(champs_par_stable_id).to eq({ 100 => 1, 101 => 1 })
+      end
+
+      it 'preserves formula values on the cloned dossier' do
+        cloned = dossier.clone
+        cloned_formule_champ = Champ.where(dossier_id: cloned.id, stable_id: 101).first
+        expect(cloned_formule_champ).to be_present
+        expect(cloned_formule_champ.value.to_s).to eq('42')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Contexte

Bug Sentry **[MES-DEMARCHES-350](https://idt.sentry.io/issues/MES-DEMARCHES-350)** : `ActiveRecord::RecordNotUnique` au clonage de dossiers sur la procédure 2439 (première mise en prod des formules). 28 occurrences, 7 utilisateurs impactés sur 14 jours.

**Cause racine** : pendant `cloned_dossier.save!`, l'autosave_association itère sur la collection `champs`. Pour chaque champ source inséré, le callback `after_save :refresh_dependent_formulas` déclenchait `compute_formulas_in_order` → `champ_upsert_by!` qui faisait un `save!` prématuré sur le Champ formule déjà présent in-memory dans `cloned_dossier.champs`. Quand autosave_association arrivait ensuite à ce même Champ formule, il tentait un second INSERT → violation de l'index unique `(dossier_id, stream, stable_id, row_id)` avec `row_id IS NULL` (Postgres en mode `NULLS NOT DISTINCT`).

## Approche : cascade explicite (kill the callback)

Le pattern « cascade implicite par callback » avait plusieurs défauts :
- 5+ gardes (`saved_change_to_value?`, formula?, stream/privacy, etc.) à maintenir
- ratait les changements sur `data` / `value_json` / `external_id` (formules sur code NAF, raison commerciale, colonnes référentielles) → trous latents
- déclenchait N×M recalculs si plusieurs champs modifiés en un PATCH
- explosait sur les flux batch (clone, prefill, rebase) qui ne devraient pas cascader

**Nouvelle convention** : tout site qui modifie un champ source appelle explicitement `dossier.refresh_formulas_after(champ)`. Les flux batch ne déclenchent rien (recalcul géré ailleurs : `compute_formulas_in_order` final pour rebase/merge, `compute_initial_formulas` pour prefill, valeurs héritées pour clone).

## Découpage en 8 commits

1. **feat** : nouvelle API `Dossier#refresh_formulas_after`
2. **refactor** : appel explicite dans controllers user/instructeur/PJ/RNA
3. **feat** : appel explicite dans mutations GraphQL annotation (8 mutations couvertes via héritage)
4. **feat** : appel explicite après update_external_data (SIRET/RNA/PJ/référentiel/API entreprise)
5. **fix** : appel explicite dans `repetition_add_row` / `repetition_remove_row` (bouche `size(bloc_repetable)`)
6. **fix** : appel explicite après `Etablissement#update_champ_value_json!` (cas SIRET dossier-level + retours jobs entreprise)
7. **fix** : suppression du callback `after_save :refresh_dependent_formulas` + spec de non-régression clone
8. **chore** : cleanup méthode orpheline, commentaires + doc CLAUDE.md

Le commit 7 est celui qui résout le bug. Si souci en prod → revert du seul commit 7 ramène à un état cohérent (callback + appel explicite = double-cascade idempotente, pas de crash mais waste perf).

## Trous bouchés au passage

Avant ce refactor, le callback ratait `saved_change_to_*?` sur `data` / `value_json` / `external_id`. Ce refactor déclenche maintenant la cascade dans :
- Webhook SIRET / API entreprise → formule sur `entreprise.raison_commerciale`
- Lookup RNA → formule sur `data['association_titre']`
- Référentiel de Polynésie → cascade prête pour évolutions futures
- `size(bloc_repetable)` → maintenant recalculé à l'add/remove row
- SIRET au niveau dossier (formulaire identité) → recalcul global des formules

## Test plan

- [x] Spec de non-régression clone : `spec/models/concerns/dossier_clone_concern_spec.rb` (context "with formula champs depending on a source") — reproduit le bug avant le fix, passe après
- [x] `bundle exec rspec spec/models/concerns/dossier_clone_concern_spec.rb` (18 examples)
- [x] `bundle exec rspec spec/models/concerns/dossier_formula_refresh_concern_spec.rb` (5 examples)
- [x] `bundle exec rspec spec/models/champs/formule_cascade_audit_spec.rb` (8 examples — scénario "chaîne linéaire" adapté pour appel explicite)
- [x] `bundle exec rspec spec/models/concerns/dossier_champs_concern_spec.rb` (51 examples)
- [x] `bundle exec rspec spec/jobs/refresh_clock_dependent_formulas_dossier_job_spec.rb`
- [x] `bundle exec rspec spec/services/api_entreprise_service_spec.rb spec/models/concerns/champ_external_data_concern_spec.rb spec/models/champs/siret_champ_spec.rb` (64 examples)
- [x] `bundle exec rspec spec/graphql/annotation_spec.rb spec/controllers/users/dossiers_controller_spec.rb spec/controllers/instructeurs/dossiers_controller_spec.rb` (319 examples)
- [x] `bundle exec rubocop` sur tous les fichiers modifiés
- [ ] Surveiller MES-DEMARCHES-350 sur Sentry après déploiement (objectif : 0 nouvelle occurrence sur 7 jours)
- [ ] Test manuel en staging : cloner un dossier de la procédure 2439

🤖 Generated with [Claude Code](https://claude.com/claude-code)