### PR TITLE
fix(sentry): nil check manquant sur @coordinate avant appel revision

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -120,8 +120,8 @@ module Administrateurs
         flash.alert = errors
       else
         @coordinate = draft.remove_type_de_champ(params[:stable_id])
-        ProcedureRevisionPreloader.load_one(@coordinate.revision)
         if @coordinate.present?
+          ProcedureRevisionPreloader.load_one(@coordinate.revision)
           @destroyed = @coordinate
           @morphed = champ_components_starting_at(@coordinate)
         end


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-30T
Occurrences (24h) : 2
Environnement : production

## Analyse
Dans `Administrateurs::TypesDeChampController#destroy`, la méthode `draft.remove_type_de_champ` peut retourner nil. L'appel `ProcedureRevisionPreloader.load_one(@coordinate.revision)` (ligne 123) était exécuté avant le check `if @coordinate.present?` (ligne 124), causant un NoMethodError quand `@coordinate` est nil.

## Fix
Déplacement de `ProcedureRevisionPreloader.load_one(@coordinate.revision)` à l'intérieur du bloc `if @coordinate.present?`, après le check nil.

Fichier modifié : `app/controllers/administrateurs/types_de_champ_controller.rb`

## Test plan
- [ ] CI verte
- [ ] Vérification manuelle par un humain
- [ ] Aucun impact sur les spécificités PF (aucun tag # pf: touché)

---
🤖 PR générée automatiquement par claude sentry-triage