### PR TITLE
fix(formule): rendu type-aware via formule_output_type (étape A)

### DIFF
--- a/app/components/editable_champ/formule_component.rb
+++ b/app/components/editable_champ/formule_component.rb
@@ -10,6 +10,6 @@ class EditableChamp::FormuleComponent < EditableChamp::EditableChampBaseComponen
   def formatted_value
     return '' if @champ.value.blank?
 
-    render FormulaValueDisplayComponent.new(value: @champ.value)
+    render FormulaValueDisplayComponent.new(value: @champ.value, output_type: type_de_champ.formule_output_type)
   end
 end

--- a/app/components/editable_champ/formule_component.rb
+++ b/app/components/editable_champ/formule_component.rb
@@ -10,6 +10,6 @@ class EditableChamp::FormuleComponent < EditableChamp::EditableChampBaseComponen
   def formatted_value
     return '' if @champ.value.blank?
 
-    render FormulaValueDisplayComponent.new(value: @champ.value, output_type: type_de_champ.formule_output_type)
+    render FormulaValueDisplayComponent.new(champ: @champ)
   end
 end

--- a/app/components/formula_value_display_component.rb
+++ b/app/components/formula_value_display_component.rb
@@ -3,27 +3,43 @@
 class FormulaValueDisplayComponent < ApplicationComponent
   include ChampHelper
 
-  def initialize(value:)
+  # pf: output_type provient du TypeDeChamp (formule_output_type) et fait foi
+  # pour le dispatch de rendu. Le fallback sniffing (output_type: nil) est
+  # conservé pour rétrocompat le temps que tous les call-sites passent le type.
+  def initialize(value:, output_type: nil)
     @value = value&.to_s&.strip
+    @output_type = output_type.presence
   end
 
   def formatted_value
     return '' if @value.blank?
 
-    if boolean?(@value)
-      format_as_boolean(@value)
-    elsif url?(@value)
-      format_as_url(@value)
-    elsif number?(@value)
-      format_as_number(@value)
-    elsif date?(@value)
-      format_as_date(@value)
+    case @output_type
+    when 'boolean'  then format_as_boolean(@value)
+    when 'date'     then format_as_date(@value)
+    when 'datetime' then format_as_datetime(@value)
+    when 'number'   then format_as_number(@value)
+    when 'string'   then format_text_value(@value)
     else
-      format_text_value(@value)
+      format_with_sniffing(@value)
     end
   end
 
   private
+
+  def format_with_sniffing(value)
+    if boolean?(value)
+      format_as_boolean(value)
+    elsif url?(value)
+      format_as_url(value)
+    elsif number?(value)
+      format_as_number(value)
+    elsif date?(value)
+      format_as_date(value)
+    else
+      format_text_value(value)
+    end
+  end
 
   def boolean?(value)
     value == Champs::BooleanChamp::TRUE_VALUE || value == Champs::BooleanChamp::FALSE_VALUE
@@ -56,22 +72,39 @@ class FormulaValueDisplayComponent < ApplicationComponent
   end
 
   def format_as_date(value)
-    begin
-      parsed_date = Date.parse(value)
-      content_tag(:time,
-                  l(parsed_date, format: :long),
-                  datetime: parsed_date.iso8601,
-                  class: 'fr-text')
-    rescue ArgumentError
-      format_text_value(value)
-    end
+    parsed_date = Date.parse(value)
+    content_tag(:time,
+                l(parsed_date, format: :long),
+                datetime: parsed_date.iso8601,
+                class: 'fr-text')
+  rescue ArgumentError
+    format_text_value(value)
+  end
+
+  def format_as_datetime(value)
+    parsed = Time.zone.parse(value)
+    return format_text_value(value) if parsed.nil?
+
+    content_tag(:time,
+                l(parsed),
+                datetime: parsed.iso8601,
+                class: 'fr-text')
+  rescue ArgumentError
+    format_text_value(value)
   end
 
   def format_as_number(value)
-    if value.include?('.')
-      number_with_precision(value.to_f, precision: 2, strip_insignificant_zeros: true)
+    # pf: Rational("195/1") → 195.0 ; rescue couvre les strings non-numériques.
+    numeric = begin
+      Rational(value).to_f
+    rescue ArgumentError, TypeError, ZeroDivisionError
+      value.to_f
+    end
+
+    if numeric == numeric.to_i && !value.include?('.')
+      number_with_delimiter(numeric.to_i)
     else
-      number_with_delimiter(value.to_i)
+      number_with_precision(numeric, precision: 2, strip_insignificant_zeros: true)
     end
   end
 end

--- a/app/components/formula_value_display_component.rb
+++ b/app/components/formula_value_display_component.rb
@@ -3,12 +3,14 @@
 class FormulaValueDisplayComponent < ApplicationComponent
   include ChampHelper
 
-  # pf: output_type provient du TypeDeChamp (formule_output_type) et fait foi
-  # pour le dispatch de rendu. Le fallback sniffing (output_type: nil) est
-  # conservé pour rétrocompat le temps que tous les call-sites passent le type.
-  def initialize(value:, output_type: nil)
-    @value = value&.to_s&.strip
-    @output_type = output_type.presence
+  # pf: On reçoit le champ entier (pas value + output_type séparés) pour
+  # garantir une source unique de vérité au call-site : un dev ne peut pas
+  # oublier de passer le type tout en passant la valeur.
+  # formule_output_type est inféré dans FormuleTypeDeChamp#validate_expression
+  # à chaque save — tout TDC formule validé en base a donc un type non-nil.
+  def initialize(champ:)
+    @value = champ.value&.to_s&.strip
+    @output_type = champ.type_de_champ.formule_output_type
   end
 
   def formatted_value
@@ -19,56 +21,15 @@ class FormulaValueDisplayComponent < ApplicationComponent
     when 'date'     then format_as_date(@value)
     when 'datetime' then format_as_datetime(@value)
     when 'number'   then format_as_number(@value)
-    when 'string'   then format_text_value(@value)
-    else
-      format_with_sniffing(@value)
+    else # 'string' ou nil (défensif) → texte brut, jamais de sniffing
+      format_text_value(@value)
     end
   end
 
   private
 
-  def format_with_sniffing(value)
-    if boolean?(value)
-      format_as_boolean(value)
-    elsif url?(value)
-      format_as_url(value)
-    elsif number?(value)
-      format_as_number(value)
-    elsif date?(value)
-      format_as_date(value)
-    else
-      format_text_value(value)
-    end
-  end
-
-  def boolean?(value)
-    value == Champs::BooleanChamp::TRUE_VALUE || value == Champs::BooleanChamp::FALSE_VALUE
-  end
-
   def format_as_boolean(value)
     value == Champs::BooleanChamp::TRUE_VALUE ? t('utils.yes') : t('utils.no')
-  end
-
-  def url?(value)
-    value.match?(/\Ahttps?:\/\//)
-  end
-
-  def date?(value)
-    # pf: Date.parse est trop permissif (accepte "Pas validé100" → date).
-    # On ne reconnaît que les formats ISO et courants explicites.
-    value.match?(/\A\d{4}-\d{2}-\d{2}/) || value.match?(/\A\d{2}\/\d{2}\/\d{4}\z/)
-  end
-
-  def number?(value)
-    value.match?(/\A-?\d+(\.\d+)?\z/)
-  end
-
-  def format_as_url(value)
-    link_to(truncate(value, length: 60), value,
-            target: '_blank',
-            rel: 'noopener noreferrer',
-            class: 'fr-link fr-link--external',
-            'aria-label': "Lien externe : #{value} (s'ouvre dans un nouvel onglet)")
   end
 
   def format_as_date(value)
@@ -93,18 +54,20 @@ class FormulaValueDisplayComponent < ApplicationComponent
     format_text_value(value)
   end
 
+  # pf: Rational("195/1") → 195.0 ; rescue couvre les strings non-numériques.
   def format_as_number(value)
-    # pf: Rational("195/1") → 195.0 ; rescue couvre les strings non-numériques.
-    numeric = begin
-      Rational(value).to_f
-    rescue ArgumentError, TypeError, ZeroDivisionError
-      value.to_f
-    end
+    numeric = parse_numeric(value)
 
     if numeric == numeric.to_i && !value.include?('.')
       number_with_delimiter(numeric.to_i)
     else
       number_with_precision(numeric, precision: 2, strip_insignificant_zeros: true)
     end
+  end
+
+  def parse_numeric(value)
+    Rational(value).to_f
+  rescue ArgumentError, TypeError, ZeroDivisionError
+    value.to_f
   end
 end

--- a/app/views/shared/champs/formule/_show.html.haml
+++ b/app/views/shared/champs/formule/_show.html.haml
@@ -1,5 +1,5 @@
 - if champ.value.present?
-  = render FormulaValueDisplayComponent.new(value: champ.value)
+  = render FormulaValueDisplayComponent.new(value: champ.value, output_type: champ.type_de_champ.formule_output_type)
 - else
   %span.fr-text--mention-grey
     Aucune valeur calculée

--- a/app/views/shared/champs/formule/_show.html.haml
+++ b/app/views/shared/champs/formule/_show.html.haml
@@ -1,5 +1,5 @@
 - if champ.value.present?
-  = render FormulaValueDisplayComponent.new(value: champ.value, output_type: champ.type_de_champ.formule_output_type)
+  = render FormulaValueDisplayComponent.new(champ: champ)
 - else
   %span.fr-text--mention-grey
     Aucune valeur calculée

--- a/docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md
+++ b/docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md
@@ -236,7 +236,70 @@ end
 
 ---
 
-## 7. Out of scope
+## 7. Scénarios système (Capybara)
+
+L'historique du champ formule a démontré que les tests unitaires et de service couvrent bien la **logique de calcul** mais ratent les bugs de la **chaîne de déclenchement** (`controller → callback AR → refresh_formulas_after → compute_formulas_in_order → affichage`). Cette section liste les scénarios end-to-end **obligatoires** pour cette PR, à écrire dans `spec/system/formula_*_spec.rb`.
+
+### S1 — Cascade entre formules après modification d'un champ source
+
+**Préconditions** :
+- Procédure publiée avec : un champ texte « Montant HT » (number), une formule A `{Montant HT} * 1.2` (libellé « TTC »), une formule B `{TTC} - {Montant HT}` (libellé « TVA »)
+- Dossier brouillon ouvert par un usager connecté
+
+**Actions** :
+1. Naviguer sur la page d'édition du dossier
+2. Saisir `100` dans le champ « Montant HT »
+3. Déclencher l'autosave (tab out ou attente)
+
+**Assertions** :
+- La valeur affichée de « TTC » est `120` immédiatement après l'autosave (vérification via `expect(page).to have_content('120')`)
+- La valeur affichée de « TVA » est `20` immédiatement après (cascade transitive)
+
+### S2 — Recalcul sur transition d'état dossier
+
+**Préconditions** :
+- Procédure publiée avec une formule référençant `{dossier_en_instruction_at}` (ex: `JOURS_ENTRE({dossier_en_instruction_at}, AUJOURDHUI())`)
+- Dossier en construction, déposé
+
+**Actions** :
+1. Se connecter en instructeur
+2. Naviguer sur le dossier, cliquer « Passer en instruction »
+
+**Assertions** :
+- Après le rechargement (ou Turbo Stream), la valeur de la formule est affichée et égale à `0` (date du jour - date du jour)
+- La page ne contient pas de marqueur « — » (valeur non calculée)
+
+### S3 — Recalcul sur modification d'identité (procédure for_individual)
+
+**Préconditions** :
+- Procédure publiée avec `for_individual: true` et une formule référençant `{individual_nom}` (ex: `CONCATENER("Bonjour ", {individual_prenom}, " ", {individual_nom})`)
+- Dossier brouillon avec identité initialement saisie (`prenom: "Jean"`, `nom: "Dupont"`)
+
+**Actions** :
+1. Naviguer sur la page identité
+2. Modifier le nom en `"Martin"`
+3. Soumettre
+
+**Assertions** :
+- Après le rechargement, la valeur de la formule affichée est `"Bonjour Jean Martin"`
+
+### S4 — Affichage type-aware (non-régression du bug d'origine)
+
+**Préconditions** :
+- Procédure publiée avec un champ date « Date d'arrivée » et un champ texte « Référence transport », et une formule (libellé « Identifiant ») de la forme `CONCATENER("", ANNEE({Date d'arrivée}), "-", {Référence transport})`
+- Dossier rempli avec `Date d'arrivée: 2026-06-08`, `Référence transport: "CAP-19297/288"`
+
+**Actions** :
+1. Naviguer sur la page de consultation du dossier
+
+**Assertions** :
+- Le résultat est affiché en clair `"2026-CAP-19297/288"` (string)
+- Le rendu HTML ne contient **pas** de balise `<time>` autour de la valeur
+- `formule_output_type` du TDC en base est `'string'` (vérification via assertion modèle complémentaire si possible)
+
+---
+
+## 8. Out of scope
 
 Les points suivants ne font pas partie de ce chantier :
 

--- a/docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md
+++ b/docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md
@@ -1,0 +1,249 @@
+# Design doc — Formule : typage d'affichage + durées N2 + graphe de dépendances unifié
+
+_Date : 2026-05-20 | Auteur : architecture review_
+
+---
+
+## 1. Contexte et motivation
+
+### Chantier 2 — Typage de retour et fonctions durée niveau 2
+
+`FormulaValueDisplayComponent` (`app/components/formula_value_display_component.rb`) effectue un type-sniffing par regex sur la string de sortie (lignes 28–44). La règle `value.match?(/\A\d{4}-\d{2}-\d{2}/)` attrape toute valeur commençant par quatre chiffres-tiret-deux chiffres-tiret-deux chiffres, y compris des concaténations comme `"2026-06-08CAP-19297/288"`, et la fait passer dans `Date.parse` + rendu `<time>`. Le bug est reproduit en prod. Le correctif consiste à passer `formule_output_type` au composant et à dispatcher sur ce type stocké plutôt que sur la forme de la valeur. Parallèlement, le DSL manque de fonctions permettant de calculer des intervalles entre deux dates (JOURS_ENTRE, MOIS_ENTRE, etc.) et d'alias explicites pour DUREE_SEMAINES qui n'existe pas encore (DUREE_ANNEES, DUREE_MOIS, DUREE_JOURS sont présents depuis `app/services/formula_calculation_service.rb`).
+
+### Chantier 4 — Graphe de dépendances unifié
+
+Le système stocke aujourd'hui trois propriétés orthogonales sur `TypeDeChamp.options` : `dependent_stable_ids` (Array d'entiers), `clock_dependent` (booléen), `state_dependent` (booléen). Ces trois champs sont détectés séparément dans `FormuleTypeDeChamp#validate_expression` et consommés dans au moins cinq endroits distincts. Les dépendances sur l'identité individu/entreprise ne sont pas modélisées, ce qui empêche les formules référençant `{individual_nom}` ou `{entreprise_siret}` de se recalculer quand l'identité change. Le remplacement par un tableau de strings `dependents` unifié permet d'encoder toutes les catégories de dépendances dans un seul champ JSON extensible et simplifie la logique de recalcul.
+
+---
+
+## 2. Décisions architecturales
+
+1. **Pas de nouveau type `:duration`** pour `formule_output_type` — les fonctions `*_ENTRE` retournent `:numeric` (entier de jours/mois/années), les `DUREE_*` retournent un offset additionnable à une date (compatible Dentaku existant). Aucune modification du système de types inféré.
+
+2. **`formule_output_type` transmis au composant via paramètre explicite** — le composant passe de `initialize(value:)` à `initialize(value:, output_type: nil)`. Un `output_type: nil` conserve le comportement actuel (fallback sniffing) pour assurer la rétrocompatibilité pendant la migration des call-sites.
+
+3. **Tableau `dependents: Array<String>`** remplace les trois clés. Convention de nommage figée : `"tdc<N>"`, `"tdc<N>/<path>"`, `"self"`, `"identite"`, `"clock"`. Les clés anciennes sont supprimées à la migration ; les méthodes publiques qui les exposaient sont remplacées par des dérivations sur `dependents`.
+
+4. **Migration data one-shot** via migration Rails (pas de maintenance task séparée) : le volume de `TypeDeChamp` formule est faible, un `UPDATE` inline dans `up` est acceptable. La migration est irréversible (`down` est un no-op documenté).
+
+5. **Triggers `identite`** ajoutés dans `Individual` et `Etablissement` via `after_commit` ; la méthode cible `Dossier#refresh_formulas_with_dependent("identite")` est ajoutée dans `DossierFormulaRefreshConcern`.
+
+---
+
+## 3. Plan d'exécution
+
+### Étape A — Corriger `FormulaValueDisplayComponent`
+
+**Quoi.** Changer la signature du composant pour accepter `output_type:`, supprimer le sniffing regex pour les cas couverts par le type stocké, conserver `format_as_number` avec conversion propre des Rational (remplacer `value.to_f` par `Rational(value).to_f rescue value.to_f` pour éviter `"195/1"`).
+
+**Fichiers touchés.**
+- `app/components/formula_value_display_component.rb` — refonte de `initialize` et `formatted_value`.
+- `app/views/shared/champs/formule/_show.html.haml` — passer `output_type: champ.type_de_champ.formule_output_type`.
+- `app/components/editable_champ/formule_component.rb` — idem dans `formatted_value`.
+
+**Test attendu.** Créer `spec/components/formula_value_display_component_spec.rb`. Scenarios : `output_type: 'string'` avec valeur `"2026-06-08CAP-19297/288"` → rendu texte sans balise `<time>` ; `output_type: 'date'` avec valeur `"2026-06-08"` → balise `<time>` ; `output_type: 'number'` avec `"195/1"` → `"195"` ; `output_type: nil` avec `"2026-06-08"` → fallback actuel (rétrocompat).
+
+**Critère de validation.** Les quatre scenarios de spec passent. `bundle exec rspec spec/components/formula_value_display_component_spec.rb`.
+
+---
+
+### Étape B — Ajouter `*_ENTRE` et `DUREE_SEMAINES` au DSL
+
+**Quoi.** Dans `FormulaCalculationService#add_french_date_functions` (ligne 294), enregistrer cinq nouvelles fonctions Dentaku : `JOURS_ENTRE`, `SEMAINES_ENTRE`, `MOIS_ENTRE`, `ANNEES_ENTRE` (toutes `:numeric`), et `DUREE_SEMAINES`. Respecter la convention nil-safe : si l'un des arguments est nil, retourner nil.
+
+Logique de `MOIS_ENTRE(d1, d2)` : `(d2.year - d1.year) * 12 + (d2.month - d1.month)`. Logique de `ANNEES_ENTRE(d1, d2)` : différence d'années révolues (même algorithme que `AGE` inversé, tenir compte si le mois/jour de d2 est avant celui de d1 dans l'année courante). `JOURS_ENTRE(d1, d2)` = `(to_date(d2) - to_date(d1)).to_i`. `SEMAINES_ENTRE` = `JOURS_ENTRE / 7` (division entière).
+
+`DUREE_SEMAINES(n)` = `n.to_i * 7` jours, sur le même modèle que `DUREE_JOURS` existant.
+
+**Fichiers touchés.**
+- `app/services/formula_calculation_service.rb` — uniquement `add_french_date_functions`.
+
+**Test attendu.** Dans `spec/services/formula_calculation_service_spec.rb`, ajouter un context `"fonctions durée"` avec au minimum : `JOURS_ENTRE` sur deux dates connues, `SEMAINES_ENTRE` (arrondi vers zéro), `MOIS_ENTRE` bord de mois (31 jan → 28 fév = 1 mois), `ANNEES_ENTRE` bord d'anniversaire (29 fév), entrée nil → nil pour chaque fonction, `DUREE_SEMAINES(2)` additionné à une date.
+
+**Critère de validation.** `bundle exec rspec spec/services/formula_calculation_service_spec.rb`.
+
+---
+
+### Étape C — Exposer les nouvelles fonctions dans `FormulaAiPromptService`
+
+**Quoi.** Dans `functions_section` de `app/services/formula_ai_prompt_service.rb` (ligne 167), ajouter sous la section "Date" les lignes de documentation des cinq nouvelles fonctions avec exemples. Vérifier que `OUTPUT_TYPE_LABELS` (ligne 15) couvre bien tous les `formule_output_type` possibles (`'date'`, `'datetime'`, `'boolean'`, `'string'`, `'number'`).
+
+**Fichiers touchés.**
+- `app/services/formula_ai_prompt_service.rb`.
+
+**Test attendu.** Ajouter un test dans `spec/services/formula_ai_prompt_service_spec.rb` (ou créer le fichier s'il n'existe pas) qui vérifie que `generate` inclut `"JOURS_ENTRE"` et `"SEMAINES_ENTRE"` dans sa sortie.
+
+**Critère de validation.** Spec verte. Vérification manuelle du prompt via l'UI de l'éditeur formule.
+
+---
+
+### Étape D — Introduire `dependents` dans `FormuleTypeDeChamp#validate_expression`
+
+**Quoi.** Dans `validate_expression` (`app/models/types_de_champ/formule_type_de_champ.rb`, ligne 126), après le calcul des flags actuels, calculer et stocker `@type_de_champ.options['dependents']` en appelant une nouvelle méthode privée `compute_dependents(expression)`. Cette méthode parse l'expression et produit un Array dédoublonné de strings selon les conventions définies. En parallèle, **conserver** le calcul de `clock_dependent` et `state_dependent` pendant cette étape — ils sont retirés à l'étape F uniquement.
+
+`compute_dependents` :
+- scan `/{tdc(\d+)(?:\/([^}]+))?}/` → `"tdc<N>"` ou `"tdc<N>/<path>"`
+- scan `/\{(dossier_number|dossier_state|dossier_depose_at|dossier_en_instruction_at|dossier_processed_at)\}/` → `"self"`
+- scan `/\{(individual_|entreprise_)/` → `"identite"`
+- présence de `AUJOURDHUI|MAINTENANT|AGE|EST_PASSEE|EST_FUTURE` (case-insensitive) → `"clock"`
+
+Ajouter `store_accessor :options, :dependents` dans `TypeDeChamp` (ligne 149).
+
+**Fichiers touchés.**
+- `app/models/types_de_champ/formule_type_de_champ.rb`
+- `app/models/type_de_champ.rb` (ligne 149 — ajouter `:dependents` à la liste `formule:`)
+
+**Test attendu.** Dans `spec/models/types_de_champ/formule_type_de_champ_spec.rb`, context `"compute_dependents"` : expression avec `{tdc42}` → `["tdc42"]` ; `{tdc42/nom}` → `["tdc42/nom"]` ; `AUJOURDHUI()` → `["clock"]` ; `{dossier_en_instruction_at}` → `["self"]` ; `{individual_nom}` → `["identite"]` ; expression mixte → dédoublonnage correct.
+
+**Critère de validation.** Spec verte + `clock_dependent` et `state_dependent` toujours calculés (pas de régression).
+
+---
+
+### Étape E — Migration data
+
+**Quoi.** Migration Rails one-shot qui, pour chaque `TypeDeChamp` de type `formule`, calcule `dependents` depuis les trois anciennes clés et l'expression stockée, écrit dans `options['dependents']`, supprime `options['dependent_stable_ids']`, `options['state_dependent']`, `options['clock_dependent']`. Voir section 4 pour le script détaillé.
+
+**Fichiers touchés.**
+- `db/migrate/YYYYMMDDHHMMSS_migrate_formula_dependents.rb` (nouveau)
+
+**Test attendu.** Spec de migration (optionnel mais recommandé) : créer un `TypeDeChamp` formule avec les anciennes clés, lancer `up`, vérifier `options['dependents']` et l'absence des anciennes clés.
+
+**Critère de validation.** `bundle exec rails db:migrate` sans erreur sur une base fraîche et sur une base avec données.
+
+---
+
+### Étape F — Adapter les consommateurs, supprimer les anciens flags
+
+**Quoi.** Mettre à jour tous les sites qui lisent `clock_dependent` / `state_dependent` / `dependent_stable_ids` :
+
+- `app/models/champ.rb` ligne 353 : `tdc.dependent_stable_ids.each` → `tdc.dependents.filter_map { |d| d.match(/\Atdc(\d+)/)&.[](1)&.to_i }.each`
+- `app/models/concerns/dossier_formula_refresh_concern.rb` :
+  - `refresh_state_dependent_formulas_if_needed` ligne 206 : `tdc.state_dependent` → `tdc.dependents&.include?("self")`
+  - `has_state_dependent_formula?` ligne 212 : idem
+  - `refresh_clock_dependent_formulas` ligne 46 : `tdc.clock_dependent` → `tdc.dependents&.include?("clock")`
+  - Renommer `refresh_state_dependent_formulas_if_needed` → `refresh_dossier_dependent_formulas_if_needed` (hook `after_commit` ligne 32 aussi)
+  - Ajouter méthode `refresh_formulas_with_dependent(dep_string)` pour les triggers `identite`
+- `app/jobs/cron/refresh_clock_dependent_formulas_job.rb` ligne 41 : remplacer `options->>'clock_dependent' = 'true'` par `options->'dependents' @> '["clock"]'::jsonb`
+- Supprimer `store_accessor` de `:clock_dependent`, `:state_dependent`, `:dependent_stable_ids` dans `TypeDeChamp` ligne 149
+
+**Fichiers touchés.**
+- `app/models/champ.rb`
+- `app/models/concerns/dossier_formula_refresh_concern.rb`
+- `app/jobs/cron/refresh_clock_dependent_formulas_job.rb`
+- `app/models/type_de_champ.rb`
+- `app/models/types_de_champ/formule_type_de_champ.rb` (retirer le calcul des anciens flags)
+
+**Test attendu.** `spec/models/concerns/dossier_formula_refresh_concern_spec.rb` : vérifier que les tests `marks the formula as clock_dependent` et `marks the formula as state_dependent` sont mis à jour pour tester `dependents.include?("clock")` et `dependents.include?("self")`. `spec/jobs/cron/refresh_clock_dependent_formulas_job_spec.rb` : vérifier que le scope SQL cible bien le nouveau format JSONB.
+
+**Critère de validation.** `bundle exec rspec spec/models/concerns/dossier_formula_refresh_concern_spec.rb spec/jobs/cron/` vert.
+
+---
+
+### Étape G — Triggers `identite` sur `Individual` et `Etablissement`
+
+**Quoi.** Ajouter dans `Individual` (`app/models/individual.rb`) un `after_commit` qui appelle `dossier.refresh_formulas_with_dependent("identite")` si `nom_previously_changed? || prenom_previously_changed? || (respond_to?(:date_de_naissance_previously_changed?) && date_de_naissance_previously_changed?)`. Même pattern dans `Etablissement` (`app/models/etablissement.rb`) sur les colonnes qui peuvent être référencées par une formule. Vérifier que `Etablissement#update_champ_value_json!` (couvert dans CLAUDE.md) ne déclenche pas de double recalcul.
+
+**Fichiers touchés.**
+- `app/models/individual.rb`
+- `app/models/etablissement.rb`
+- `app/models/concerns/dossier_formula_refresh_concern.rb` (ajout de `refresh_formulas_with_dependent`)
+
+**Test attendu.** Nouveau context dans `spec/models/concerns/dossier_formula_refresh_concern_spec.rb` : procédure `for_individual`, formule référençant `{individual_nom}`, modification de `individual.nom` → valeur de la formule recalculée. Idem pour `Etablissement`.
+
+**Critère de validation.** Spec verte. Aucune cascade infinie (vérifié par absence de stack overflow ou boucle infinie dans le test).
+
+---
+
+## 4. Migration data
+
+```ruby
+# db/migrate/YYYYMMDDHHMMSS_migrate_formula_dependents.rb
+class MigrateFormulaDependents < ActiveRecord::Migration[7.0]
+  CLOCK_FUNCTIONS = /AUJOURDHUI|MAINTENANT|AGE|EST_PASSEE|EST_FUTURE/i
+  DOSSIER_REFS    = /\{(dossier_number|dossier_state|dossier_depose_at|dossier_en_instruction_at|dossier_processed_at)\}/
+  IDENTITE_REFS   = /\{(individual_|entreprise_)/
+  TDC_REF         = /\{tdc(\d+)(?:\/([^}]+))?\}/
+
+  def up
+    TypeDeChamp.where(type_champ: 'formule').find_each do |tdc|
+      opts = tdc.options || {}
+      expr = opts['formule_expression'].to_s
+
+      deps = []
+
+      expr.scan(TDC_REF) do |id, path|
+        deps << (path ? "tdc#{id}/#{path}" : "tdc#{id}")
+      end
+      deps << "self"     if expr.match?(DOSSIER_REFS)
+      deps << "identite" if expr.match?(IDENTITE_REFS)
+      deps << "clock"    if expr.match?(CLOCK_FUNCTIONS)
+      deps.uniq!
+
+      new_opts = opts
+        .merge('dependents' => deps)
+        .except('dependent_stable_ids', 'clock_dependent', 'state_dependent')
+
+      # pf: update_column skip les callbacks — pas de cascade parasite
+      tdc.update_column(:options, new_opts)
+    end
+  end
+
+  def down
+    # pf: non réversible — les anciens flags ne sont pas recalculés en down
+    # car cela nécessiterait de recharger FormulaCalculationService.
+    # En cas de rollback, relancer validate_expression sur chaque TDC formule.
+  end
+end
+```
+
+**Ordre d'exécution :** lancer avant le déploiement du code de l'étape F (les consommateurs ne lisent plus les anciens flags). La migration peut tourner en parallèle du trafic : `update_column` est atomique par ligne, pas de verrou global.
+
+**Rollback :** si nécessaire avant le déploiement F, les anciens flags sont encore en place dans la base. Si le rollback intervient après le déploiement F, relancer `FormulaTypeDeChamp#validate_expression` sur tous les TDC formule via une rake task.
+
+---
+
+## 5. Risques et mitigations
+
+**(a) Formules existantes en prod.** La migration écrit `dependents` sans supprimer les anciens flags tant que le code de l'étape F n'est pas déployé. Les deux représentations coexistent. Si la migration est accidentellement jouée sans le code F, les consommateurs continuent de lire les anciens flags (pas de régression immédiate).
+
+**(b) Cascade infinie.** Le guard `return if champ.type_de_champ.formule?` (ligne 73 de `dossier_formula_refresh_concern.rb`) empêche qu'une formule déclenchée en cascade re-déclenche une cascade. Le trigger `identite` appelle `refresh_formulas_with_dependent` qui doit appeler `compute_formulas_in_order` (pas `refresh_formulas_after`) pour rester dans le même périmètre sans re-entrer dans les hooks.
+
+**(c) Perf du recalcul transitif.** `dependent_formula_stable_ids` effectue un BFS en mémoire sur les TDC de la révision (pas d'accès BDD par nœud). La complexité est O(N formules). Pour les procédures à très nombreuses formules chaînées (> 50), ajouter un circuit-breaker `MAX_CHAIN_DEPTH = 20` avec log Sentry si dépassé.
+
+**(d) Compatibilité GraphQL.** `formule_output_type` n'est pas exposé dans le schéma GraphQL public actuellement. Aucun impact. Si exposé à l'avenir, les valeurs `'date'` et `'datetime'` sont déjà dans le domaine du champ — pas de breaking change.
+
+---
+
+## 6. Tests d'intégration
+
+### Specs de référence à étendre
+
+**`spec/models/concerns/dossier_formula_refresh_concern_spec.rb`** — ajouter :
+- Context `"with identite dependency"` : procédure `for_individual`, formule `SI({individual_nom} == "TEST", 1, 0)`, modification de `individual.nom` → formule recalculée.
+- Context `"with state dependency via dependents"` : vérifier que le recalcul est déclenché après `passer_en_instruction!` quand `dependents.include?("self")`.
+
+**`spec/models/champs/formule_cascade_audit_spec.rb`** (existant, à étendre) — spec de non-régression documentée dans CLAUDE.md. Doit couvrir :
+- Formule A dépend de champ source X → modification de X recalcule A.
+- Formule B dépend de formule A → modification de X recalcule A puis B (transitivité).
+- Formule avec `dependents: ["clock"]` → recalculée par `RefreshClockDependentFormulasDossierJob` et non par `refresh_formulas_after`.
+- Formule avec `dependents: ["identite"]` → recalculée par le trigger `Individual#after_commit`.
+
+### Nouveaux scenarios
+
+- `JOURS_ENTRE` dans une formule sur dossier → valeur recalculée quand source date change.
+- Composant affiche texte `"2026-06-08CAP-19297/288"` sans balise `<time>` quand `output_type: 'string'`.
+- `DUREE_SEMAINES(3)` additionné à une date → date + 21 jours.
+
+---
+
+## 7. Out of scope
+
+Les points suivants ne font pas partie de ce chantier :
+
+- Preview temps-réel du résultat dans l'éditeur formule (avant sauvegarde du TDC).
+- Badge "calculé automatiquement" visible par l'usager sur le champ formule.
+- Autocomplete des nouvelles fonctions dans `formula_autocomplete_controller.ts`.
+- Type `:duration` comme `formule_output_type` exposable.
+- Agrégation sur blocs répétables (`SOMME.SI`, `NBLIGNES`).
+- Exposition de `dependents` dans l'API GraphQL publique.
+- Nettoyage du format legacy `{123}` (entier nu sans préfixe `tdc`) dans `dependent_stable_ids` — la migration lit les deux formats mais le stockage en `dependents` ne perpétue que le format `tdc<N>`.

--- a/docs/superpowers/specs/2026-05-21-formule-repetitions-design.md
+++ b/docs/superpowers/specs/2026-05-21-formule-repetitions-design.md
@@ -1,0 +1,303 @@
+# Design doc — Formule : agrégation sur blocs répétables
+
+_Date : 2026-05-21 | Auteur : architecture review_
+
+Spec complémentaire à `2026-05-20-formule-typage-dependances-design.md`. Indépendante en lecture, exécutable en PR distincte.
+
+---
+
+## 1. Contexte et motivation
+
+Le champ formule supporte déjà les **formules-ligne** : une formule placée à l'intérieur d'un bloc répétable s'exécute par ligne et accède aux champs de sa ligne courante (cf. `formule_champ.row_id` consommé dans `FormulaCalculationService`). Ce qui manque, et que demandent 6 cas sur 15 du catalogue d'usage (FIPTH, médico-social, transports, pension de famille, accidents environnementaux, perliculture) :
+
+> Une formule **hors** du bloc qui **agrège** un sous-champ de toutes les lignes du bloc.
+
+Exemples concrets :
+- `SOMME({Lignes de facture/Prix HT})` — somme des prix de toutes les lignes
+- `COUNT({Investisseurs personne physique})` — nombre de lignes
+- `SOMME({Lignes de facture/Prix HT}) - SOMME({Paiements/Montant})` — reste à payer
+
+Aucune fonction custom à inventer : Dentaku 3.5.4 supporte nativement `SUM`, `COUNT`, `MAX`, `MIN`, `AVG` sur des arrays passés en binding. Le travail se limite à **étendre la résolution de référence** pour reconnaître deux nouvelles formes et construire les bindings adaptés.
+
+---
+
+## 2. Décisions architecturales
+
+1. **Notation `{Libellé du bloc}` et `{Libellé du bloc/Libellé sous-champ}`** — extension de la convention `/` déjà utilisée pour les sous-propriétés JSON (`{tdc456/date_de_naissance}`). Disambiguïté par dispatch sur le type du TDC parent : `repetition` → résolution sous-champ ; sinon → JSON path existant. Aucune collision possible (un bloc répétable n'a pas de sous-propriété JSON).
+
+2. **Binding `{bloc}` = Array de row_ids opaques** (`[42, 43, 44]`). Coût quasi nul (`champs.map(&:row_id).uniq`), suffisant pour `COUNT`, extensible plus tard vers array de hashes si MAP exposé un jour. **Pas de hash de contenu en v1** — YAGNI.
+
+3. **Binding `{bloc/sous_champ}` = Array de scalaires type-aware**, identique à la conversion appliquée pour les références scalaires (Date native, Integer, etc. — via `format_value_for_dentaku`).
+
+4. **Pas de MAP exposé à l'admin en v1**. Les cas de transformation par ligne (`prix_ht * 1.2 si <1000 sinon * 1.1`) passent par une **formule-ligne intermédiaire** dans le bloc, puis agrégation extérieure. Cohérent avec ce qui fonctionne déjà, sans nouveau scoping de variable à inventer.
+
+5. **Placement obligatoire en dessous du bloc** — validation explicite à l'enregistrement du TDC formule. Convention de dépendance descendante alignée sur `compute_formulas_in_order` (ordre de position).
+
+6. **Granularité de dépendance = niveau bloc**. Une formule-agrégat enregistre `"tdc<stable_id_du_bloc>"` dans `dependents` (cf. chantier #4). Toute modification d'un sous-champ d'une ligne, ou ajout/suppression de ligne, déclenche le recalcul. Sur-recalcul léger acceptable.
+
+---
+
+## 3. Plan d'exécution
+
+### Étape A — Étendre `FormulaColumnResolver` pour reconnaître les blocs
+
+**Quoi.** Dans `FormulaColumnResolver#build_columns_index` (`app/services/formula_column_resolver.rb`), ajouter une entrée par TDC `repetition` dans la révision, identifiée par son libellé (à côté des `tdc<N>` existants). Idem pour chaque sous-TDC d'une repetition, accessible via `bloc_label/sub_label`.
+
+**Fichiers touchés.**
+- `app/services/formula_column_resolver.rb`
+
+**Test attendu.** `spec/services/formula_column_resolver_spec.rb` — context « blocs répétables » :
+- Résoudre `"Lignes de facture"` → renvoie un descripteur pointant le TDC repetition
+- Résoudre `"Lignes de facture/Prix HT"` → renvoie un descripteur composite (bloc + sous-tdc)
+- Résoudre `"Bloc inconnu"` → `nil` (pas d'erreur fatale)
+
+**Critère de validation.** Spec verte.
+
+---
+
+### Étape B — Résolution dans `FormulaCalculationService`
+
+**Quoi.** Dans `resolve_column_references` (`app/services/formula_calculation_service.rb` ~ ligne 375), ajouter deux cas avant le dispatch existant sur JSON path :
+
+```ruby
+def resolve_column_references(expression)
+  expression.gsub(/\{([^}]+)\}/) do |_match|
+    reference = Regexp.last_match(1).strip
+    bloc_label, sub_label = reference.split('/', 2)
+    target = @resolver.resolve(bloc_label)
+
+    if target&.is_a?(TypeDeChamp) && target.repetition?
+      if sub_label.present?
+        register_variable(extract_repetition_values(target, sub_label))
+      else
+        register_variable(extract_repetition_rows(target))
+      end
+    else
+      # Logique existante (scalaire, JSON path, colonne système)
+      resolve_existing(reference)
+    end
+  end
+end
+
+def extract_repetition_rows(bloc_tdc)
+  all_champs
+    .select { |c| c.parent_id == bloc_tdc.stable_id }
+    .map(&:row_id)
+    .compact
+    .uniq
+end
+
+def extract_repetition_values(bloc_tdc, sub_label)
+  sub_tdc = bloc_tdc.types_de_champ.find { |t| t.libelle == sub_label }
+  return [] unless sub_tdc
+
+  rows = all_champs.select { |c| c.parent_id == bloc_tdc.stable_id }
+  rows.group_by(&:row_id).values.map do |row_champs|
+    champ = row_champs.find { |c| c.stable_id == sub_tdc.stable_id }
+    format_value_for_dentaku(champ&.value, sub_tdc.type_champ.to_sym)
+  end
+end
+```
+
+**Fichiers touchés.**
+- `app/services/formula_calculation_service.rb`
+
+**Test attendu.** `spec/services/formula_calculation_service_spec.rb` — context « agrégation sur répétition » :
+- `SOMME({Lignes/Prix HT})` sur un bloc à 3 lignes (100, 200, 50) → 350
+- `COUNT({Lignes})` sur un bloc à 3 lignes → 3
+- `MAX({Lignes/Prix HT})` → 200
+- `MOYENNE({Lignes/Prix HT})` → 116.67
+- Bloc vide : `SOMME` → 0, `COUNT` → 0, `MAX` → nil (comportement Dentaku natif)
+- Ligne avec sous-champ nil : nil ignoré dans l'agrégation
+- Combinaison : `SOMME({Lignes/Prix HT}) - SOMME({Paiements/Montant})` → reste à payer
+
+**Critère de validation.** `bundle exec rspec spec/services/formula_calculation_service_spec.rb` vert.
+
+---
+
+### Étape C — Validation : placement obligatoire en dessous du bloc
+
+**Quoi.** Dans `TypesDeChamp::FormuleTypeDeChamp#validate_expression` (`app/models/types_de_champ/formule_type_de_champ.rb`), ajouter une règle de validation `forward_reference?` étendue : pour chaque référence détectée à un TDC repetition, vérifier que ce TDC est positionné **avant** le TDC formule dans l'ordre de la révision. Si non, ajouter une erreur `:invalid_placement` avec un message clair.
+
+L'algorithme existant `forward_reference?` (ligne ~311) qui détecte déjà les références à un TDC postérieur peut être réutilisé tel quel — un bloc répétable est un TDC normal du point de vue de la position.
+
+**Fichiers touchés.**
+- `app/models/types_de_champ/formule_type_de_champ.rb`
+- `config/locales/models/type_de_champ/fr.yml` (message d'erreur)
+
+**Test attendu.** `spec/models/types_de_champ/formule_type_de_champ_spec.rb` :
+- Formule placée AVANT le bloc référencé → invalide avec message « Le bloc 'X' doit être placé avant la formule »
+- Formule placée APRÈS le bloc → valide
+
+**Critère de validation.** Spec verte. Vérification manuelle dans l'éditeur.
+
+---
+
+### Étape D — Enregistrement des dépendances
+
+**Quoi.** Dans la méthode `compute_dependents` (ajoutée par le chantier #2+#4), ajouter la détection des références à blocs et sous-champs :
+
+- `{Libellé bloc}` → résoudre vers `stable_id` du bloc → ajouter `"tdc<N>"` à `dependents`
+- `{Libellé bloc/Libellé sous-champ}` → résoudre vers le `stable_id` du **bloc parent** (pas du sous-champ) → ajouter `"tdc<N>"` à `dependents`
+
+Granularité bloc : si n'importe quelle ligne ou sous-champ change, la formule-agrégat se recalcule. Simple et suffisant.
+
+**Fichiers touchés.**
+- `app/models/types_de_champ/formule_type_de_champ.rb` (dans `compute_dependents`)
+
+**Test attendu.** Dans `formule_type_de_champ_spec.rb`, context `compute_dependents` :
+- Expression avec `{Lignes/Prix HT}` → `dependents` inclut `"tdc<id_bloc>"`
+- Expression avec `{Lignes}` seul → idem
+- Pas de duplication si plusieurs sous-champs du même bloc référencés
+
+**Critère de validation.** Spec verte.
+
+---
+
+### Étape E — Triggers de recalcul sur ligne ajoutée/supprimée/modifiée
+
+**Quoi.** Vérifier que les flux existants déclenchent bien le recalcul des formules-agrégat :
+
+1. **Modification d'un sous-champ d'une ligne** — le sous-champ a son propre `stable_id` (différent du bloc). Pour qu'une formule dépendante de `"tdc<bloc_id>"` se recalcule quand `tdc<sub_id>` change, il faut que `dependent_formula_stable_ids` (`app/models/champ.rb`) reconnaisse que la modification d'un sous-champ doit déclencher les formules qui dépendent du bloc parent.
+
+   **Adaptation** : dans `Champ#dependent_formula_stable_ids`, quand le champ a un `parent_id`, propager la dépendance au TDC parent : `seeds << tdc_parent.stable_id` en plus du `stable_id` du sous-champ lui-même.
+
+2. **Ajout/suppression de ligne** — `Dossier#repetition_add_row` et `Dossier#repetition_remove_row` (cf. CLAUDE.md) appellent déjà `refresh_formulas_after` pour les sous-champs. Vérifier qu'elles appellent aussi le refresh pour le TDC bloc lui-même (le bloc n'a pas de valeur scalaire mais le compteur de lignes change). Adapter si nécessaire.
+
+**Fichiers touchés.**
+- `app/models/champ.rb` (propagation de la dépendance parent)
+- `app/models/dossier.rb` (méthodes `repetition_add_row` / `repetition_remove_row` si besoin)
+
+**Test attendu.** Dans `spec/models/champs/formule_cascade_audit_spec.rb` (existant, déjà ciblé par #2+#4) :
+- Modification d'un sous-champ d'une ligne → formule-agrégat se recalcule
+- Ajout d'une ligne → `COUNT({bloc})` augmente de 1
+- Suppression d'une ligne → `COUNT({bloc})` diminue de 1
+
+**Critère de validation.** Spec verte. Test manuel sur une procédure pilote (FIPTH ou perliculture).
+
+---
+
+### Étape F — Enrichir `FormulaAiPromptService`
+
+**Quoi.** Dans `app/services/formula_ai_prompt_service.rb`, ajouter dans la documentation générée pour l'IA :
+- Section « Agrégation sur blocs répétables »
+- Syntaxes `{Libellé bloc}` et `{Libellé bloc/Libellé sous-champ}`
+- Exemples : `SOMME`, `COUNT`, `MAX`, `MIN`, `MOYENNE`
+- Convention de placement (formule en dessous du bloc)
+- Pattern de transformation par ligne via formule-ligne intermédiaire (avec un exemple complet)
+
+**Fichiers touchés.**
+- `app/services/formula_ai_prompt_service.rb`
+
+**Test attendu.** `spec/services/formula_ai_prompt_service_spec.rb` :
+- Le prompt généré inclut « SOMME({Bloc/Sous-champ}) »
+- Le prompt inclut une mention de la limitation placement
+
+**Critère de validation.** Spec verte. Vérification manuelle du prompt copié.
+
+---
+
+### Étape H — Alias français additionnels pour fonctions natives Dentaku
+
+**Quoi.** Ajouter au hash de `config/initializers/dentaku_french_aliases.rb` les alias FR pour les fonctions natives Dentaku utiles qui n'en ont pas encore. Mettre à jour `FormulaAiPromptService#functions_section` (`app/services/formula_ai_prompt_service.rb`) pour les exposer.
+
+**Liste retenue** (validée par observation du catalogue d'usage + tests Dentaku 3.5.4) :
+
+| Native Dentaku | Alias FR | Catégorie prompt IA |
+|---|---|---|
+| `count` | `NB` (+ alias secondaire `COMPTE`) | Stats / agrégation |
+| `rounddown` | `ARRONDI_INF` | Arithmétique |
+| `roundup` | `ARRONDI_SUP` | Arithmétique |
+| `floor` | `PLANCHER` | Arithmétique |
+| `ceil` / `ceiling` | `PLAFOND` | Arithmétique |
+| `sqrt` | `RACINE` | Arithmétique |
+| `median` | `MEDIANE` | Stats |
+
+**Note tokenisation Dentaku** : les noms Excel-français usuels `ARRONDI.INF` / `ARRONDI.SUP` ne sont **pas** utilisables — le tokenizer Dentaku traite le `.` comme un séparateur d'accès propriété (testé : `ARRONDI.INF(3.7, 0)` est tokenisé comme `identifier:"arrondi.inf"` et lève `Invalid statement` à l'évaluation). On utilise donc l'underscore, conforme aux autres alias Dentaku.
+
+**Note prompt IA** : ne pas changer la formulation « Fonctions autorisées (liste exhaustive) » — la posture FR-first est volontaire. Ajouter optionnellement une phrase de clarification : « Les noms anglais équivalents (`LEFT`, `RIGHT`, `ROUND`, `ROUNDDOWN`, `ROUNDUP`, `FLOOR`, `CEIL`, `SQRT`, `MEDIAN`, `COUNT`) fonctionnent aussi nativement, mais préfère les noms FR par cohérence avec les autres formules. »
+
+**Fichiers touchés.**
+- `config/initializers/dentaku_french_aliases.rb` — ajout des entrées
+- `app/services/formula_ai_prompt_service.rb` — enrichissement des sections « Arithmétique » et nouvelle ligne `NB(array)` dans la section dédiée aux blocs répétables
+
+**Test attendu.** Dans `spec/services/formula_calculation_service_spec.rb`, ajouter un context « alias FR additionnels » avec un test par alias vérifiant que la formule retourne le même résultat que sa contrepartie anglaise :
+- `ARRONDI_INF(3.7, 0)` → 3
+- `ARRONDI_SUP(3.2, 0)` → 4
+- `PLANCHER(5.8)` → 5
+- `PLAFOND(5.2)` → 6
+- `RACINE(16)` → 4
+- `NB(arr)` avec `arr = [1,2,3]` → 3
+- `MEDIANE(arr)` avec `arr = [1,2,3,4,5]` → 3
+
+**Critère de validation.** Spec verte. Probe manuel via l'éditeur formule pour vérifier le rendu du prompt IA.
+
+---
+
+### Étape G — Autocomplete étendu
+
+**Quoi.** Dans `app/javascript/controllers/formula_autocomplete_controller.ts`, étendre la liste des références proposées :
+- Ajouter les TDCs de type `repetition` (libellé du bloc)
+- Quand l'admin a déjà tapé `{Libellé bloc/`, proposer les sous-champs du bloc à la suite
+- Préserver l'insertion par libellé exact (cf. ligne 411 : `{${column.label}}`)
+
+Cette étape est UI-only, isolable du reste, peut partir en PR distincte des étapes A→F si besoin.
+
+**Fichiers touchés.**
+- `app/javascript/controllers/formula_autocomplete_controller.ts`
+- Side data : la liste des colonnes envoyée au front (probablement via `app/controllers/...` ou data-attribute).
+
+**Test attendu.** Test système (Capybara) : ouvrir l'éditeur formule, taper `{`, vérifier qu'un bloc apparaît dans les suggestions ; taper `{Bloc/`, vérifier qu'un sous-champ apparaît.
+
+**Critère de validation.** Spec système verte. Test manuel.
+
+---
+
+## 4. Migration data
+
+**Aucune migration nécessaire.** Le chantier #3 n'ajoute pas de nouveau champ persistant — `dependents` (existant après #2+#4) accueille naturellement les `"tdc<bloc_stable_id>"`. Les formules existantes ne référencent pas de blocs (la syntaxe ne le permettait pas), donc rien à reconvertir.
+
+---
+
+## 5. Risques et mitigations
+
+**(a) Régression Dentaku sur MAP/PLUCK/SUM/COUNT non documentés.** Le probe a confirmé que ces fonctions marchent en 3.5.4 sur des arrays passés en binding, mais l'absence de doc officielle pose un risque de breaking change à une future upgrade. **Mitigation** : pinning de la version Dentaku dans le `Gemfile` (à vérifier), et **spec sentinelle** `spec/lib/dentaku_array_functions_spec.rb` qui exerce `SUM`, `COUNT`, `MAX`, `MIN`, `AVG` sur arrays bindings — si Dentaku casse ces fonctions, la CI le voit avant la prod.
+
+**(b) Collision de libellé entre bloc et champ scalaire.** Si une procédure a un bloc « X » et un champ scalaire « X » au même niveau, l'autocomplete et le resolver doivent choisir. **Mitigation** : les validations existantes du modèle interdisent déjà les libellés en doublon dans une même section ? À vérifier. Sinon, ajouter une validation explicite côté formule (priorité au bloc, ou erreur de validation).
+
+**(c) Lignes vides ou sous-champ nil.** `SOMME([100, nil, 50])` en Dentaku — comportement à vérifier. **Mitigation** : test explicite dans la spec (étape B) ; si Dentaku jette une erreur sur nil, filter nil au moment de construire le binding (à arbitrer selon le résultat du test).
+
+**(d) Performance sur gros blocs.** Une procédure pourrait avoir un bloc à >500 lignes. La résolution itère sur tous les sous-champs (`all_champs.select { ... }`). **Mitigation** : `all_champs` est déjà chargé une fois par calcul, donc le coût est O(N) sur les sous-champs du bloc, pas de N+1 SQL. Acceptable sur 500 lignes (~quelques ms). Au-delà de 10 000 lignes, à reconsidérer — mais hors scope v1.
+
+**(e) Disambiguïté `bloc/sous_champ` vs JSON path.** Le dispatch sur le type du TDC parent (`repetition` vs autre) tranche sans ambiguïté. **Mitigation** : test explicite dans la spec qui couvre les deux cas dans la même expression.
+
+---
+
+## 6. Tests d'intégration
+
+### Specs à étendre / créer
+
+**`spec/services/formula_calculation_service_spec.rb`** — context « agrégation sur répétition » :
+- Cas d'usage complet de la démarche 3311 FIPTH (Repetition budget + cohérence éligible/octroyé)
+- Cas d'usage 1611 perliculture (somme des destinations vs collecté)
+
+**`spec/models/champs/formule_cascade_audit_spec.rb`** (existant, étendu par #2+#4) :
+- Modification d'un sous-champ → formule-agrégat recalculée
+- Ajout/suppression de ligne → `COUNT` et `SOMME` à jour
+
+**`spec/lib/dentaku_array_functions_spec.rb`** (nouveau, sentinelle) :
+- `Dentaku::Calculator.new.evaluate!("SUM(arr)", arr: [1,2,3])` → 6
+- Idem `COUNT`, `MAX`, `MIN`, `AVG`
+- Si une de ces specs casse à une upgrade Dentaku, on sait que la résolution agrégat va régresser
+
+---
+
+## 7. Out of scope
+
+- **MAP, REDUCE, FILTER exposés à l'admin** — pas en v1. Les transformations par ligne passent par formule-ligne intermédiaire.
+- **Agrégation filtrée (`COUNT_WHERE`, `SUM_WHERE`)** — pas en v1. Réalisable via formule-ligne `SI(...)` + agrégation, cf. patterns du catalogue.
+- **Binding `{bloc}` en array de hashes complets** — option B abandonnée au profit de l'array de row_ids (option A). Si un futur besoin émerge (MAP exposé), on enrichira la résolution sans changer la syntaxe admin.
+- **Agrégation cross-bloc ou cross-procédure** — hors périmètre.
+- **Sucre syntaxique alternatif** (`{bloc}.SOMME` style méthode) — pas envisagé, Dentaku ne le supporte pas naturellement.
+- **Modification de l'éditeur admin pour visualiser le placement (warning visuel quand formule au-dessus d'un bloc référencé)** — relève du chantier UI séparé (cf. audit design `2026-05-20` P0 preview).
+- **Alias FR avec point séparateur** (`ARRONDI.INF`, `ARRONDI.SUP`) — bloqué par la tokenisation Dentaku (le `.` est traité comme accès propriété). Substitution par underscore (`ARRONDI_INF`) retenue. Si la limitation Dentaku saute dans une upgrade future, on pourra renommer.

--- a/docs/superpowers/specs/2026-05-21-formule-repetitions-design.md
+++ b/docs/superpowers/specs/2026-05-21-formule-repetitions-design.md
@@ -292,7 +292,59 @@ Cette étape est UI-only, isolable du reste, peut partir en PR distincte des ét
 
 ---
 
-## 7. Out of scope
+## 7. Scénarios système (Capybara)
+
+Comme pour la spec #2+#4, ces scénarios sont **obligatoires** dans la PR. À écrire dans `spec/system/formula_repetitions_*_spec.rb`.
+
+### S5 — Recalcul d'un agrégat à l'ajout d'une ligne de bloc
+
+**Préconditions** :
+- Procédure publiée avec : un bloc répétable « Lignes de facture » contenant un sous-champ « Prix HT » (decimal number), et une formule placée **en dessous** du bloc, libellée « Total », formule `SOMME({Lignes de facture/Prix HT})`
+- Dossier brouillon avec 2 lignes déjà saisies (Prix HT : 100, 200)
+
+**Actions** :
+1. Naviguer sur la page d'édition du dossier
+2. Vérifier la valeur initiale de « Total » : `300`
+3. Cliquer « Ajouter une ligne »
+4. Saisir `50` dans le Prix HT de la nouvelle ligne
+5. Déclencher l'autosave
+
+**Assertions** :
+- Après l'autosave, « Total » affiche `350`
+- `COUNT({Lignes de facture})` (si présent dans une autre formule) affiche `3`
+
+### S6 — Recalcul à la modification d'un sous-champ d'une ligne existante
+
+**Préconditions** :
+- Même procédure et même dossier que S5 (2 lignes, Total = 300)
+
+**Actions** :
+1. Modifier le Prix HT de la première ligne : `100` → `150`
+2. Déclencher l'autosave
+
+**Assertions** :
+- Après l'autosave, « Total » affiche `350`
+- Le recalcul est déclenché **sans** rechargement complet de la page (vérification via absence de FOUC ou via Turbo Stream)
+
+### S7 — Validation de placement à l'enregistrement du TDC
+
+**Préconditions** :
+- Administrateur connecté sur l'éditeur d'une procédure brouillon
+- Procédure avec un bloc « Lignes de facture » + sous-champ « Prix HT »
+
+**Actions** :
+1. Créer un nouveau champ formule **avant** le bloc dans l'ordre des champs
+2. Saisir l'expression `SOMME({Lignes de facture/Prix HT})`
+3. Cliquer « Enregistrer »
+
+**Assertions** :
+- Le formulaire affiche une erreur de validation : « Le bloc 'Lignes de facture' doit être placé avant la formule » (ou équivalent localisé)
+- Le TDC formule n'est **pas** enregistré (vérifier `TypeDeChamp.where(libelle: ...).count == 0` après l'action)
+- À l'inverse : déplacer la formule en dessous du bloc puis enregistrer → succès
+
+---
+
+## 8. Out of scope
 
 - **MAP, REDUCE, FILTER exposés à l'admin** — pas en v1. Les transformations par ligne passent par formule-ligne intermédiaire.
 - **Agrégation filtrée (`COUNT_WHERE`, `SUM_WHERE`)** — pas en v1. Réalisable via formule-ligne `SI(...)` + agrégation, cf. patterns du catalogue.

--- a/spec/components/formula_value_display_component_spec.rb
+++ b/spec/components/formula_value_display_component_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 describe FormulaValueDisplayComponent, type: :component do
-  subject { render_inline(described_class.new(value: value, output_type: output_type)) }
+  subject { render_inline(described_class.new(champ: champ)) }
 
+  let(:type_de_champ) { build(:type_de_champ_formule, formule_output_type: output_type) }
+  let(:champ) { instance_double(Champs::FormuleChamp, value: value, type_de_champ: type_de_champ) }
   let(:output_type) { nil }
+  let(:value) { nil }
 
-  context 'with output_type: "string"' do
+  context 'with output_type "string"' do
     let(:output_type) { 'string' }
 
     context 'and a value that starts with an ISO date prefix' do
@@ -30,7 +33,7 @@ describe FormulaValueDisplayComponent, type: :component do
     end
   end
 
-  context 'with output_type: "date"' do
+  context 'with output_type "date"' do
     let(:output_type) { 'date' }
     let(:value) { '2026-06-08' }
 
@@ -40,7 +43,7 @@ describe FormulaValueDisplayComponent, type: :component do
     end
   end
 
-  context 'with output_type: "datetime"' do
+  context 'with output_type "datetime"' do
     let(:output_type) { 'datetime' }
     let(:value) { '2026-06-08T15:40:00+02:00' }
 
@@ -50,7 +53,7 @@ describe FormulaValueDisplayComponent, type: :component do
     end
   end
 
-  context 'with output_type: "number"' do
+  context 'with output_type "number"' do
     let(:output_type) { 'number' }
 
     context 'with a Rational-like string "195/1"' do
@@ -82,7 +85,7 @@ describe FormulaValueDisplayComponent, type: :component do
     end
   end
 
-  context 'with output_type: "boolean"' do
+  context 'with output_type "boolean"' do
     let(:output_type) { 'boolean' }
 
     context 'when true' do
@@ -96,24 +99,16 @@ describe FormulaValueDisplayComponent, type: :component do
     end
   end
 
-  context 'with output_type: nil (legacy sniffing for backwards compatibility)' do
+  context 'with output_type nil (defensive — should not happen in practice)' do
     let(:output_type) { nil }
 
     context 'with an ISO date value' do
       let(:value) { '2026-06-08' }
 
-      it 'falls back to date rendering' do
+      it 'does NOT auto-detect a date (no sniffing fallback)' do
         subject
-        expect(page).to have_selector('time')
-      end
-    end
-
-    context 'with a URL' do
-      let(:value) { 'https://example.com' }
-
-      it 'renders a link' do
-        subject
-        expect(page).to have_selector('a[href="https://example.com"]')
+        expect(page).to have_text('2026-06-08')
+        expect(page).not_to have_selector('time')
       end
     end
 

--- a/spec/components/formula_value_display_component_spec.rb
+++ b/spec/components/formula_value_display_component_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+describe FormulaValueDisplayComponent, type: :component do
+  subject { render_inline(described_class.new(value: value, output_type: output_type)) }
+
+  let(:output_type) { nil }
+
+  context 'with output_type: "string"' do
+    let(:output_type) { 'string' }
+
+    context 'and a value that starts with an ISO date prefix' do
+      # pf: bug d'origine — "2026-06-08CAP-19297/288" était parsé comme date
+      # par le sniffing regex et rendu dans une balise <time>.
+      let(:value) { '2026-06-08CAP-19297/288' }
+
+      it 'renders the raw text without a <time> tag' do
+        subject
+        expect(page).to have_text('2026-06-08CAP-19297/288')
+        expect(page).not_to have_selector('time')
+      end
+    end
+
+    context 'and a value that looks numeric' do
+      let(:value) { '195/1' }
+
+      it 'renders the raw text without number formatting' do
+        subject
+        expect(page).to have_text('195/1')
+      end
+    end
+  end
+
+  context 'with output_type: "date"' do
+    let(:output_type) { 'date' }
+    let(:value) { '2026-06-08' }
+
+    it 'renders a <time> tag with ISO datetime' do
+      subject
+      expect(page).to have_selector('time[datetime="2026-06-08"]')
+    end
+  end
+
+  context 'with output_type: "datetime"' do
+    let(:output_type) { 'datetime' }
+    let(:value) { '2026-06-08T15:40:00+02:00' }
+
+    it 'renders a <time> tag' do
+      subject
+      expect(page).to have_selector('time')
+    end
+  end
+
+  context 'with output_type: "number"' do
+    let(:output_type) { 'number' }
+
+    context 'with a Rational-like string "195/1"' do
+      let(:value) { '195/1' }
+
+      it 'renders 195 (no Rational artefact)' do
+        subject
+        expect(page).to have_text('195')
+        expect(page).not_to have_text('195/1')
+      end
+    end
+
+    context 'with a decimal string' do
+      let(:value) { '12.50' }
+
+      it 'renders with French formatting' do
+        subject
+        expect(page).to have_text('12,5')
+      end
+    end
+
+    context 'with an integer string' do
+      let(:value) { '1234' }
+
+      it 'renders with thousand delimiter' do
+        subject
+        expect(page).to have_text(number_with_delimiter(1234))
+      end
+    end
+  end
+
+  context 'with output_type: "boolean"' do
+    let(:output_type) { 'boolean' }
+
+    context 'when true' do
+      let(:value) { Champs::BooleanChamp::TRUE_VALUE }
+      it { subject; expect(page).to have_text(I18n.t('utils.yes')) }
+    end
+
+    context 'when false' do
+      let(:value) { Champs::BooleanChamp::FALSE_VALUE }
+      it { subject; expect(page).to have_text(I18n.t('utils.no')) }
+    end
+  end
+
+  context 'with output_type: nil (legacy sniffing for backwards compatibility)' do
+    let(:output_type) { nil }
+
+    context 'with an ISO date value' do
+      let(:value) { '2026-06-08' }
+
+      it 'falls back to date rendering' do
+        subject
+        expect(page).to have_selector('time')
+      end
+    end
+
+    context 'with a URL' do
+      let(:value) { 'https://example.com' }
+
+      it 'renders a link' do
+        subject
+        expect(page).to have_selector('a[href="https://example.com"]')
+      end
+    end
+
+    context 'with a blank value' do
+      let(:value) { '' }
+
+      it 'renders empty' do
+        subject
+        expect(page.text).to eq('')
+      end
+    end
+  end
+
+  def number_with_delimiter(n)
+    ActionController::Base.helpers.number_with_delimiter(n)
+  end
+end


### PR DESCRIPTION
## Summary

Première étape du chantier **formule typage + dépendances** ([design doc](docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md) + [ajustements](docs/superpowers/specs/2026-05-21-formule-typage-dependances-ajustements.md)).

Corrige un bug de rendu où `FormulaValueDisplayComponent` faisait du type-sniffing par regex sur la valeur. La règle `\A\d{4}-\d{2}-\d{2}` attrapait des concaténations type `"2026-06-08CAP-19297/288"` et les passait dans `Date.parse` + balise `<time>`.

### Changements

- **Signature** : `FormulaValueDisplayComponent.new(champ:)` au lieu de `(value:, output_type:)`. Source unique de vérité au call-site — un dev ne peut pas oublier l'un en passant l'autre.
- **Suppression du fallback sniffing** (Aj-4 de la revue critique) : `formule_output_type` est inféré au save dans `validate_expression`, tous les TDC en base l'ont. Le fallback masquait des bugs réels (ex : `"003"` rendu `"3"`).
- **`format_as_number`** utilise `Rational(value).to_f` pour gérer `"195/1"` proprement (factorisé dans `parse_numeric`).
- **Rendu `datetime`** explicite (balise `<time>` avec ISO 8601).
- **Call-sites** : `_show.html.haml` et `editable_champ/formule_component.rb` passent `champ:`.

### Scope hors PR

Étapes B → G du chantier (fonctions `*_ENTRE`, graphe `formule_deps` unifié, triggers identité) → PRs suivantes (PR #443 pour B+C en cours).
Scénarios système Capybara (S1-S4) → en fin de chantier.

## Test plan

- [x] 11 specs unit verts : `bundle exec rspec spec/components/formula_value_display_component_spec.rb`
- [x] Specs voisins (`spec/components/editable_champ/`) verts → pas de régression call-sites
- [x] Rubocop local vert sur les deux composants
- [ ] CI verte (en attente du build après push d27d5576f9)
- [ ] Vérification manuelle UI : formule retournant une string construite affichée en clair (pas de balise `<time>` parasite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)