### PR TITLE
feat(formule): fonctions *_ENTRE et DUREE_SEMAINES (étapes B+C)

### DIFF
--- a/app/services/formula_ai_prompt_service.rb
+++ b/app/services/formula_ai_prompt_service.rb
@@ -16,6 +16,8 @@ class FormulaAiPromptService
     'string' => 'texte',
     'number' => 'nombre',
     'boolean' => 'booléen (true/false)',
+    'date' => 'date',
+    'datetime' => 'date et heure',
   }.freeze
 
   # pf: Types de colonnes exposés par available_columns_for_formula_editor
@@ -205,8 +207,12 @@ class FormulaAiPromptService
       - `AGE(date_de_naissance)` → nombre — âge en années révolues (tient compte de l’anniversaire)
       - `EST_PASSEE(date)` → booléen — la date est-elle strictement antérieure à aujourd’hui ?
       - `EST_FUTURE(date)` → booléen — la date est-elle strictement postérieure à aujourd’hui ?
-      - `DUREE_ANNEES(n)` / `DUREE_MOIS(n)` / `DUREE_JOURS(n)` → durée — à utiliser en arithmétique avec une date. Ex : `{DateNaissance} + DUREE_ANNEES(18)` → date du 18e anniversaire.
+      - `DUREE_ANNEES(n)` / `DUREE_MOIS(n)` / `DUREE_JOURS(n)` / `DUREE_SEMAINES(n)` → durée — à utiliser en arithmétique avec une date. Ex : `{DateNaissance} + DUREE_ANNEES(18)` → date du 18e anniversaire, ou `AUJOURDHUI() + DUREE_SEMAINES(2)` → date dans deux semaines.
       - `DURATION(n, years|months|days)` → durée — équivalent anglais natif, interchangeable avec les `DUREE_*`.
+      - `JOURS_ENTRE(date1, date2)` → nombre — nombre de jours entre deux dates (négatif si date2 < date1). Ex : `JOURS_ENTRE({Date d'arrivée}, AUJOURDHUI())`.
+      - `SEMAINES_ENTRE(date1, date2)` → nombre — nombre de semaines complètes (division entière par 7).
+      - `MOIS_ENTRE(date1, date2)` → nombre — différence en mois calendaires (31 jan → 28 fév vaut 1).
+      - `ANNEES_ENTRE(date1, date2)` → nombre — années révolues entre deux dates (tient compte de l'anniversaire ; équivalent à `AGE` généralisé à deux dates).
 
       Opérations dérivées de l’arithmétique native :
       - `{Date1} - {Date2}` → nombre de jours entre deux dates (entier si les deux sont des dates simples).

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -352,10 +352,12 @@ class FormulaCalculationService
       next nil if d1.nil? || d2.nil?
       (to_date(d2) - to_date(d1)).to_i
     })
-    # pf: division entière → arrondi vers zéro (5 jours = 0 semaine).
+    # pf: Troncature vers zéro (5 jours → 0 semaine, -5 jours → 0 semaine).
+    # Pas la division entière Ruby (qui fait floor vers -∞).
     calculator.add_function(:SEMAINES_ENTRE, :numeric, -> (d1, d2) {
       next nil if d1.nil? || d2.nil?
-      ((to_date(d2) - to_date(d1)).to_i / 7)
+      days = (to_date(d2) - to_date(d1)).to_i
+      days.abs.div(7) * (days.negative? ? -1 : 1)
     })
     # pf: Différence en mois calendaires, indépendante du jour du mois
     # (31 jan → 28 fév = 1, comme attendu par les usagers).
@@ -366,17 +368,19 @@ class FormulaCalculationService
       (b.year - a.year) * 12 + (b.month - a.month)
     })
     # pf: Années révolues (même logique que AGE, généralisée à deux dates).
-    # Si le mois/jour de d2 est avant celui de d1 dans l'année courante,
-    # on retire une année.
+    # Symétrique : ANNEES_ENTRE(a, b) == -ANNEES_ENTRE(b, a).
+    # On calcule toujours sur (min, max) puis on rétablit le signe.
     calculator.add_function(:ANNEES_ENTRE, :numeric, -> (d1, d2) {
       next nil if d1.nil? || d2.nil?
       a = to_date(d1)
       b = to_date(d2)
-      years = b.year - a.year
-      if b.month < a.month || (b.month == a.month && b.day < a.day)
+      sign = b >= a ? 1 : -1
+      from, to = sign == 1 ? [a, b] : [b, a]
+      years = to.year - from.year
+      if to.month < from.month || (to.month == from.month && to.day < from.day)
         years -= 1
       end
-      years
+      years * sign
     })
   end
 

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -340,6 +340,44 @@ class FormulaCalculationService
     calculator.add_function(:DUREE_JOURS, :duration, -> (n) {
       Dentaku::AST::Duration::Value.new(n.to_i, 'days')
     })
+    # pf: DUREE_SEMAINES(n) = n * 7 jours — pas de unit 'weeks' dans Dentaku,
+    # on retombe sur 'days'.
+    calculator.add_function(:DUREE_SEMAINES, :duration, -> (n) {
+      Dentaku::AST::Duration::Value.new(n.to_i * 7, 'days')
+    })
+
+    # pf: Intervalles entre deux dates. Toutes nil-safe (n'importe quel
+    # argument nil → retourne nil pour propager le manque de donnée).
+    calculator.add_function(:JOURS_ENTRE, :numeric, -> (d1, d2) {
+      next nil if d1.nil? || d2.nil?
+      (to_date(d2) - to_date(d1)).to_i
+    })
+    # pf: division entière → arrondi vers zéro (5 jours = 0 semaine).
+    calculator.add_function(:SEMAINES_ENTRE, :numeric, -> (d1, d2) {
+      next nil if d1.nil? || d2.nil?
+      ((to_date(d2) - to_date(d1)).to_i / 7)
+    })
+    # pf: Différence en mois calendaires, indépendante du jour du mois
+    # (31 jan → 28 fév = 1, comme attendu par les usagers).
+    calculator.add_function(:MOIS_ENTRE, :numeric, -> (d1, d2) {
+      next nil if d1.nil? || d2.nil?
+      a = to_date(d1)
+      b = to_date(d2)
+      (b.year - a.year) * 12 + (b.month - a.month)
+    })
+    # pf: Années révolues (même logique que AGE, généralisée à deux dates).
+    # Si le mois/jour de d2 est avant celui de d1 dans l'année courante,
+    # on retire une année.
+    calculator.add_function(:ANNEES_ENTRE, :numeric, -> (d1, d2) {
+      next nil if d1.nil? || d2.nil?
+      a = to_date(d1)
+      b = to_date(d2)
+      years = b.year - a.year
+      if b.month < a.month || (b.month == a.month && b.day < a.day)
+        years -= 1
+      end
+      years
+    })
   end
 
   # pf: Les fonctions date acceptent indifféremment Date/DateTime/Time.

--- a/docs/superpowers/specs/2026-05-21-formule-typage-dependances-ajustements.md
+++ b/docs/superpowers/specs/2026-05-21-formule-typage-dependances-ajustements.md
@@ -1,0 +1,291 @@
+# Ajustements à la spec formule typage/dépendances
+
+_Date : 2026-05-21 | Source : revue critique xhigh du design 2026-05-20_
+
+---
+
+## Contexte
+
+Le design original [`2026-05-20-formule-typage-dependances-design.md`] est en
+cours d'exécution. **Étapes A et B déjà réalisées.** Une revue critique a fait
+émerger quatre ajustements à appliquer sur les étapes restantes (C → G) +
+des corrections factuelles. Ce document est un **patch** sur la spec
+d'origine — à lire en complément, pas à la place.
+
+---
+
+## Aj-1 — Format de stockage : Hash structuré au lieu d'`Array<String>`
+
+**Impact : Étape D, Étape E, Étape F.**
+
+La spec d'origine propose `options['dependents']` comme un `Array<String>` avec
+conventions de nommage figées (`"tdc<N>"`, `"self"`, `"clock"`, `"identite"`).
+
+**Nouveau format retenu** : `options['formule_deps']` est un **Hash**, avec
+convention « clé absente ⇒ false » pour les flags :
+
+```ruby
+options['formule_deps'] = {
+  'champs'       => [42, 78],          # Array<Integer> (stable_ids, sans path)
+  'has_clock'    => true,              # absent ou false ⇒ pas de fonction d'horloge
+  'has_state'    => true,              # absent ⇒ pas de ref {dossier_*_at}
+  'has_identite' => true               # absent ⇒ pas de ref {individual_*}/{entreprise_*}
+}
+```
+
+**Justification.**
+- Lecture directe O(1), pas de parsing string au runtime côté consommateur.
+- Extensibilité préservée : ajouter `'has_external_data' => true` demain ne
+  casse pas les TDC existants (lecture d'une clé absente ⇒ `nil` ⇒ falsy).
+- Format auto-documenté (les clés portent le nom de la catégorie).
+
+**Notes de format.**
+- Le path éventuel d'une référence (`{tdc42/nom}` → la sous-propriété `nom`)
+  **n'est pas conservé** dans `champs` : on garde uniquement le stable_id pour
+  l'usage actuel (déclenchement de cascade). Le path n'a pas de consommateur
+  identifié aujourd'hui (cf. `Champ#dependent_formula_stable_ids` qui ne
+  l'utilise pas).
+- Hash sérialisé via le `WithIndifferentAccess` déjà en place sur `options`.
+
+**Convention de nommage du store accessor.**
+- Clé options : `'formule_deps'` (plutôt que `'dependents'` qui est ambigu).
+- `store_accessor :options, :formule_deps` dans `TypeDeChamp` (ligne 149,
+  liste `formule:`).
+
+---
+
+## Aj-2 — Calculer `has_clock` via l'AST Dentaku, pas par regex
+
+**Impact : Étape D.**
+
+La spec d'origine propose un scan regex `/AUJOURDHUI|MAINTENANT|AGE|EST_PASSEE|EST_FUTURE/i`
+pour `has_clock`. C'est ce que fait déjà
+`FormulaCalculationService.clock_dependent?` aujourd'hui.
+
+**Défaut** : la regex match dans les littéraux de chaîne. Exemple :
+
+```
+CONCATENER("L'AGE(x) est dans le détail", {Nom})
+```
+
+→ matche `AGE(` → `has_clock = true` à tort → recalcul quotidien inutile.
+
+**Correctif** : l'AST Dentaku distingue `Dentaku::AST::Function` (nœud d'appel
+de fonction) d'un `Dentaku::AST::Literal` (string). On a déjà l'AST construit
+ligne 188 de `validate_expression` (`ast_node = calculator.ast(testable)`).
+Le walker est trivial :
+
+```ruby
+CLOCK_FUNCTION_NAMES = Set[:AUJOURDHUI, :MAINTENANT, :AGE, :EST_PASSEE, :EST_FUTURE].freeze
+
+def ast_uses_function?(node, function_names)
+  return false if node.nil?
+  return true if node.respond_to?(:class) && function_names.include?(node.class.name)
+  children = node.respond_to?(:args) ? node.args :
+             [node.respond_to?(:left) ? node.left : nil,
+              node.respond_to?(:right) ? node.right : nil].compact
+  children.any? { |c| ast_uses_function?(c, function_names) }
+end
+```
+
+**Cantonnement strict de l'AST à `has_clock`.**
+- `has_state` (refs `{dossier_*_at}`), `has_identite` (refs `{individual_*}` /
+  `{entreprise_*}`), `champs` (refs `{tdc<N>}`) restent en **regex** sur
+  l'expression brute. Les `{}` sont des délimiteurs syntaxiques Dentaku
+  (jamais dans un littéral string), donc la regex est sûre par construction.
+- Seules les **fonctions** ont besoin de l'AST (un identifiant nu type `AGE`
+  peut apparaître dans un littéral).
+
+**Note de robustesse** : si l'AST n'est pas construit (échec de parsing — cas
+où la formule est invalide), `has_clock` est mis à `false` par défaut. Le
+recalcul cron passera à côté, mais une formule invalide n'a de toute façon
+pas de valeur à recalculer.
+
+---
+
+## Aj-3 — Trigger `identite` : appel explicite dans le controller, pas d'`after_commit`
+
+**Impact : Étape G (refonte).**
+
+La spec d'origine propose un `after_commit` sur `Individual` et `Etablissement`
+qui appelle `dossier.refresh_formulas_with_dependent("identite")`.
+
+**Problème** : viole la convention documentée dans `CLAUDE.md` :
+
+> Convention : la cascade est explicite, pas implicite par callback.
+>
+> Tout site qui modifie un champ source d'une formule doit appeler
+> explicitement `dossier.refresh_formulas_after(champ)`.
+
+**Approche retenue** : appels explicites dans les controllers qui modifient
+l'identité, pas de callback AR.
+
+**Sites à instrumenter.**
+
+1. `app/controllers/users/dossiers_controller.rb#update_identite` (ligne 179)
+   — après `@dossier.update(dossier_params) && @dossier.individual.valid?`,
+   ajouter :
+
+   ```ruby
+   @dossier.refresh_formulas_with_identite_dependents
+   ```
+
+2. `app/controllers/users/dossiers_controller.rb#update_siret` /
+   `create_etablissement_and_redirect` — après création/MAJ de l'établissement
+   lié au dossier, même appel.
+
+3. Vérifier `APIEntrepriseService#create_etablissement` (mentionné dans
+   CLAUDE.md comme déjà site de cascade via `update_champ_value_json!`) :
+   probablement déjà couvert par la cascade champ → ajouter la couverture
+   identite seulement si ce site modifie aussi `Etablissement` hors du flux
+   champ (vérification à faire par le dév).
+
+**Méthode à ajouter dans `DossierFormulaRefreshConcern`.**
+
+```ruby
+def refresh_formulas_with_identite_dependents
+  matching = revision.types_de_champ.filter do |tdc|
+    tdc.formule? && tdc.formule_deps&.[]('has_identite')
+  end
+  return if matching.empty?
+  compute_formulas_in_order(only: matching.map(&:stable_id).to_set)
+end
+```
+
+Pas d'`after_commit` ajouté sur `Individual` ni sur `Etablissement`.
+
+---
+
+## Aj-4 — Retirer entièrement le sniffing du composant, pas en fallback
+
+**Impact : Étape A (déjà partiellement faite — point à revérifier).**
+
+La spec d'origine garde le sniffing regex comme fallback quand
+`output_type: nil`. C'est inutile :
+
+- `output_type` est inféré dans `validate_expression`
+  (ligne 194 de `formule_type_de_champ.rb`) à chaque save d'une formule.
+- Tous les TDC formule en base ont donc un `output_type` non-nil dès qu'ils
+  ont été validés une fois. Pas de cas légitime de `nil`.
+- Garder le sniffing protège contre un défaut imaginaire et masque les vrais
+  bugs (cas `"003"` rendu comme `"3"` parce que le sniffing voit un entier).
+
+**Action à demander au dév.**
+- Vérifier que `FormulaValueDisplayComponent` n'a plus de chemin
+  `output_type.nil?` qui retombe sur sniffing.
+- Si la signature est `initialize(value:, output_type: nil)` : changer en
+  `initialize(champ:)` ou `initialize(value:, output_type:)` **sans default**
+  pour rendre l'oubli détectable.
+
+**Recommandation forte** : passer **le champ** plutôt que `value:` + `output_type:`,
+pour garantir une source unique de vérité au call-site et éviter qu'un dev
+futur passe l'un sans l'autre :
+
+```ruby
+# _show.html.haml
+= render FormulaValueDisplayComponent.new(champ: champ)
+
+# Component
+def initialize(champ:)
+  @value = champ.value&.to_s&.strip
+  @output_type = champ.type_de_champ.formule_output_type
+end
+```
+
+---
+
+## Corrections factuelles
+
+### CF-1 — Étape B déjà entièrement implémentée
+
+Les cinq fonctions de l'Étape B existent déjà dans
+`app/services/formula_calculation_service.rb` :
+
+- `DUREE_SEMAINES` (lignes 345–347)
+- `JOURS_ENTRE` (lignes 351–354)
+- `SEMAINES_ENTRE` (lignes 356–359)
+- `MOIS_ENTRE` (lignes 362–367)
+- `ANNEES_ENTRE` (lignes 371–380)
+
+→ Le dév peut **sauter l'Étape B** (le code et — selon ce qui a été réalisé —
+les tests sont déjà en place). Vérifier juste que les tests existent dans
+`spec/services/formula_calculation_service_spec.rb` (sinon les ajouter).
+
+### CF-2 — Scénario S3 : corriger les noms de variables
+
+La spec utilise `{individual_nom}` et `{individual_prenom}` qui **n'existent
+pas** dans le résolveur. Cf. `app/services/formula_column_resolver.rb` lignes
+63–66 :
+
+```ruby
+index['individual_gender'] = ...
+index['individual_first_name'] = ... # mapping vers la colonne `prenom`
+index['individual_last_name'] = ...  # mapping vers la colonne `nom`
+```
+
+→ Remplacer dans S3 :
+- `{individual_nom}` → `{individual_last_name}`
+- `{individual_prenom}` → `{individual_first_name}`
+
+Idem pour la doc IA (Étape C) si elle référence ces variables : utiliser les
+noms exposés par le résolveur, sinon les formules suggérées par l'IA seront
+invalides.
+
+### CF-3 — `dependent_stable_ids` n'était pas stocké à l'origine
+
+La spec d'origine présente trois propriétés orthogonales stockées
+(`dependent_stable_ids`, `clock_dependent`, `state_dependent`). En réalité,
+**seuls les deux booléens étaient écrits dans `options`**.
+`TypeDeChamp#dependent_stable_ids` (ligne 466) re-parsait l'expression à
+chaque appel.
+
+→ Conséquence pratique pour la **migration data** (Étape E) : on n'a rien à
+nettoyer côté `options['dependent_stable_ids']` (clé absente partout). À
+nettoyer en base : `clock_dependent`, `state_dependent`. À écrire :
+`formule_deps`. Adapter le script en conséquence.
+
+---
+
+## Récap des actions par étape du plan
+
+| Étape | Statut | Action |
+|---|---|---|
+| A | partiellement faite | Appliquer Aj-4 (retirer le sniffing fallback). Préférer signature `champ:` |
+| B | **faite** | Vérifier que les specs des cinq fonctions existent (CF-1) |
+| C | à faire | Documenter les fonctions ajoutées dans `formula_ai_prompt_service.rb` |
+| D | à faire | Appliquer Aj-1 (format Hash) + Aj-2 (AST pour `has_clock`). Renommer `dependents` → `formule_deps`. Toujours conserver `clock_dependent` / `state_dependent` tant que les consommateurs (Étape F) n'ont pas migré |
+| E | à faire | Adapter la migration au format Hash + CF-3 (pas de `dependent_stable_ids` à supprimer) |
+| F | à faire | Adapter les 5 consommateurs au format Hash (cf. table ci-dessous) |
+| G | **refonte** | Appliquer Aj-3 (appels explicites controllers, pas d'`after_commit`) |
+
+### Détail consommateurs Étape F (adaptation au format Hash)
+
+| Fichier | Avant | Après |
+|---|---|---|
+| `app/models/champ.rb` ligne 353 | `tdc.dependent_stable_ids.each` | `(tdc.formule_deps&.[]('champs') \|\| []).each` |
+| `app/models/concerns/dossier_formula_refresh_concern.rb` ligne 206 | `tdc.state_dependent` | `tdc.formule_deps&.[]('has_state')` |
+| `app/models/concerns/dossier_formula_refresh_concern.rb` ligne 47 | `tdc.clock_dependent` | `tdc.formule_deps&.[]('has_clock')` |
+| `app/jobs/cron/refresh_clock_dependent_formulas_job.rb` ligne 41 | `options->>'clock_dependent' = 'true'` | `options->'formule_deps'->>'has_clock' = 'true'` |
+| `app/models/procedure_revision.rb` ligne 229 | `other_tdc.dependent_stable_ids.include?(stable_id)` | `(other_tdc.formule_deps&.[]('champs') \|\| []).include?(stable_id)` |
+
+### Détail spécifique Aj-3 (Étape G refondue)
+
+- **Ne pas créer** : aucun `after_commit` sur `Individual` ni sur `Etablissement`.
+- **Ajouter dans `DossierFormulaRefreshConcern`** : méthode
+  `refresh_formulas_with_identite_dependents` (snippet ci-dessus).
+- **Modifier** : `Users::DossiersController#update_identite` et
+  `update_siret` / `create_etablissement_and_redirect` pour appeler la
+  méthode après modification réussie.
+- **Spec** : ajouter dans
+  `spec/controllers/users/dossiers_controller_spec.rb` (pas dans le concern
+  spec) un test qui vérifie qu'un `update_identite` recalcule les formules
+  `has_identite` du dossier.
+
+---
+
+## Hors scope (inchangé)
+
+Les points "out of scope" de la spec d'origine restent valides : pas de
+preview temps-réel, pas de badge, pas d'autocomplete des nouvelles fonctions,
+pas de type `:duration` exposable, pas d'agrégation en répétition, pas
+d'exposition `formule_deps` en GraphQL.

--- a/spec/services/formula_ai_prompt_service_spec.rb
+++ b/spec/services/formula_ai_prompt_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe FormulaAiPromptService do
+  describe '#generate' do
+    let(:type_de_champ) { build(:type_de_champ_formule, formule_output_type: output_type) }
+    let(:coordinate) { instance_double(ProcedureRevisionTypeDeChamp) }
+    let(:output_type) { 'number' }
+
+    before do
+      allow(coordinate).to receive(:available_columns_for_formula_editor).and_return([])
+      allow(coordinate).to receive(:revision).and_return(double(types_de_champ: []))
+      allow(coordinate).to receive(:child?).and_return(false)
+    end
+
+    subject { described_class.new(type_de_champ: type_de_champ, coordinate: coordinate).generate }
+
+    it 'documents the new *_ENTRE date functions' do
+      expect(subject).to include('JOURS_ENTRE')
+      expect(subject).to include('SEMAINES_ENTRE')
+      expect(subject).to include('MOIS_ENTRE')
+      expect(subject).to include('ANNEES_ENTRE')
+    end
+
+    it 'documents DUREE_SEMAINES' do
+      expect(subject).to include('DUREE_SEMAINES')
+    end
+
+    context 'when output_type is "date"' do
+      let(:output_type) { 'date' }
+
+      it 'labels the expected return type as "date"' do
+        expect(subject).to match(/Type de résultat attendu.*\*\*date\*\*/m)
+      end
+    end
+
+    context 'when output_type is "datetime"' do
+      let(:output_type) { 'datetime' }
+
+      it 'labels the expected return type as a date+heure' do
+        expect(subject).to match(/Type de résultat attendu.*date.*heure/mi)
+      end
+    end
+  end
+end

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -609,6 +609,13 @@ describe FormulaCalculationService do
           expect(compute('SEMAINES_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_JOURS(14))')).to eq('2')
         end
 
+        it 'SEMAINES_ENTRE truncates toward zero on negative ranges' do
+          # -5 jours → 0 semaine (et pas -1 comme le ferait la division entière Ruby)
+          expect(compute('SEMAINES_ENTRE(AUJOURDHUI(), AUJOURDHUI() - DUREE_JOURS(5))')).to eq('0')
+          # -13 jours → -1 semaine
+          expect(compute('SEMAINES_ENTRE(AUJOURDHUI(), AUJOURDHUI() - DUREE_JOURS(13))')).to eq('-1')
+        end
+
         it 'MOIS_ENTRE handles month boundary (31 jan → 28 feb = 1 month)' do
           travel_to Time.zone.local(2026, 1, 31) do
             expect(compute('MOIS_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_JOURS(28))')).to eq('1')
@@ -632,6 +639,17 @@ describe FormulaCalculationService do
           # d1 = 2020-02-29, d2 = 2024-02-29 → 4 ans
           travel_to Time.zone.local(2020, 2, 29) do
             expect(compute('ANNEES_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_ANNEES(4))')).to eq('4')
+          end
+        end
+
+        it 'ANNEES_ENTRE is symmetric: f(a, b) == -f(b, a)' do
+          # d1 = 2020-02-28, d2 = 2024-02-29 → 4 ans
+          # Inversé : d1 = 2024-02-29, d2 = 2020-02-28 → -4 ans (pas -5)
+          travel_to Time.zone.local(2020, 2, 28) do
+            expect(compute('ANNEES_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_ANNEES(4) + DUREE_JOURS(1))')).to eq('4')
+          end
+          travel_to Time.zone.local(2024, 2, 29) do
+            expect(compute('ANNEES_ENTRE(AUJOURDHUI(), AUJOURDHUI() - DUREE_ANNEES(4) - DUREE_JOURS(1))')).to eq('-4')
           end
         end
       end

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -579,6 +579,63 @@ describe FormulaCalculationService do
         end
       end
 
+      describe 'DUREE_SEMAINES' do
+        it 'Date + DUREE_SEMAINES adds n * 7 days' do
+          travel_to Time.zone.local(2026, 4, 19) do
+            expect(compute('AUJOURDHUI() + DUREE_SEMAINES(2)')).to eq('2026-05-03')
+          end
+        end
+
+        it 'Date - DUREE_SEMAINES subtracts n * 7 days' do
+          travel_to Time.zone.local(2026, 4, 19) do
+            expect(compute('AUJOURDHUI() - DUREE_SEMAINES(1)')).to eq('2026-04-12')
+          end
+        end
+      end
+
+      describe 'JOURS_ENTRE / SEMAINES_ENTRE / MOIS_ENTRE / ANNEES_ENTRE' do
+        it 'JOURS_ENTRE returns the day difference' do
+          expect(compute('JOURS_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_JOURS(10))')).to eq('10')
+        end
+
+        it 'JOURS_ENTRE can be negative when d2 is before d1' do
+          expect(compute('JOURS_ENTRE(AUJOURDHUI(), AUJOURDHUI() - DUREE_JOURS(3))')).to eq('-3')
+        end
+
+        it 'SEMAINES_ENTRE returns integer weeks (truncated toward zero)' do
+          # 13 jours → 1 semaine
+          expect(compute('SEMAINES_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_JOURS(13))')).to eq('1')
+          # 14 jours → 2 semaines
+          expect(compute('SEMAINES_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_JOURS(14))')).to eq('2')
+        end
+
+        it 'MOIS_ENTRE handles month boundary (31 jan → 28 feb = 1 month)' do
+          travel_to Time.zone.local(2026, 1, 31) do
+            expect(compute('MOIS_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_JOURS(28))')).to eq('1')
+          end
+        end
+
+        it 'MOIS_ENTRE returns 12 across a full year' do
+          travel_to Time.zone.local(2026, 1, 1) do
+            expect(compute('MOIS_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_ANNEES(1))')).to eq('12')
+          end
+        end
+
+        it 'ANNEES_ENTRE handles 29 feb leap-year edge (anniversary not yet passed)' do
+          # d1 = 2020-02-29, d2 = 2024-02-28 → 3 ans (anniv pas encore atteint)
+          travel_to Time.zone.local(2020, 2, 29) do
+            expect(compute('ANNEES_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_ANNEES(4) - DUREE_JOURS(1))')).to eq('3')
+          end
+        end
+
+        it 'ANNEES_ENTRE returns 4 once the anniversary is reached' do
+          # d1 = 2020-02-29, d2 = 2024-02-29 → 4 ans
+          travel_to Time.zone.local(2020, 2, 29) do
+            expect(compute('ANNEES_ENTRE(AUJOURDHUI(), AUJOURDHUI() + DUREE_ANNEES(4))')).to eq('4')
+          end
+        end
+      end
+
       describe 'DURATION (native Dentaku)' do
         it 'exposes DURATION natively with years/months/days identifiers' do
           travel_to Time.zone.local(2026, 4, 19) do


### PR DESCRIPTION
## Summary

Étapes B et C du chantier **formule typage + dépendances** ([design doc](docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md)).

Ajoute cinq fonctions au DSL formule et les expose dans le prompt IA :

- `JOURS_ENTRE(d1, d2)`, `SEMAINES_ENTRE`, `MOIS_ENTRE`, `ANNEES_ENTRE` → `:numeric`, toutes nil-safe.
- `DUREE_SEMAINES(n)` = `n * 7` jours, complète la famille `DUREE_*`.

Pas de nouveau type `:duration` exposé : les `*_ENTRE` retournent un entier, ce qui les rend additionnables/comparables avec les fonctions arithmétiques existantes sans changer le système de types inféré.

`ANNEES_ENTRE` applique le même algorithme que `AGE` (généralisé à deux dates) — testé sur le cas limite 29 février.

`FormulaAiPromptService` documente ces nouvelles fonctions et complète `OUTPUT_TYPE_LABELS` avec `'date'` et `'datetime'` (qui manquaient).

### Indépendance vis-à-vis de l'étape A

Cette PR est ouverte depuis `devpf`, **indépendamment** de la PR #442 (étape A — refonte `FormulaValueDisplayComponent`). Les deux peuvent merger dans n'importe quel ordre.

### Scope hors PR

Étapes D → G (graphe `dependents` unifié, triggers identité, migration data) → PRs suivantes.
Scénarios système Capybara (S1–S4) → en fin de chantier.

## Test plan

- [x] 9 nouveaux scenarios dans `formula_calculation_service_spec.rb` (nominal, négatif, bord 31 jan→28 fév, semaine arrondie, 29 fév anniv avant/après)
- [x] 4 scenarios dans le nouveau `formula_ai_prompt_service_spec.rb` (présence des fonctions, labels date/datetime)
- [x] Fichier complet `formula_calculation_service_spec.rb` : 99/99 vert (pas de régression)
- [ ] Vérification manuelle de l'éditeur formule (UI) : prompt IA copié contient bien les nouvelles fonctions

🤖 Generated with [Claude Code](https://claude.com/claude-code)