### PR TITLE
feat(formule): graphe de dépendances unifié dans options[formule_deps] (étape D)

### DIFF
--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -146,7 +146,7 @@ class TypeDeChamp < ApplicationRecord
     te_fenua: [:parcelles, :batiments, :zones_manuelles, :te_fenua_layer],
     lexpol: [:lexpol_modele, :lexpol_mapping],
     visa: [:accredited_users],
-    formule: [:formule_expression, :dependent_stable_ids, :formule_output_type, :clock_dependent, :state_dependent],
+    formule: [:formule_expression, :dependent_stable_ids, :formule_output_type, :clock_dependent, :state_dependent, :formule_deps],
   }
   INSTANCE_OPTIONS = INSTANCE_OPTIONS_BY_TYPE.values.reduce(&:+).uniq
   INSTANCE_CHAMPS_PARAMS = [:numero_dn, :date_de_naissance]

--- a/app/models/types_de_champ/formule_type_de_champ.rb
+++ b/app/models/types_de_champ/formule_type_de_champ.rb
@@ -372,14 +372,18 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
   # fonction clock. Les noeuds personnalises (add_function) ont
   # node.class.name comme Symbol (ex: :AGE) ; les noeuds built-in ont
   # node.class.name comme String. On s'appuie sur ce discriminant.
+  # pf: Dentaku::AST::Negation stocke son operande dans @node (accesseur :node),
+  # pas dans :left/:right. On descend explicitement dans :node pour ne pas
+  # manquer un appel clock enveloppe par un unaire (ex: -AGE({tdc42})).
   def ast_uses_clock_function?(node)
     return false if node.nil?
     return true if node.class.name.is_a?(Symbol) && CLOCK_FUNCTION_NAMES.include?(node.class.name)
 
     children = []
-    children.concat(node.args) if node.respond_to?(:args)
+    children.concat(node.args) if node.respond_to?(:args) && node.args
     children << node.left if node.respond_to?(:left) && node.left
     children << node.right if node.respond_to?(:right) && node.right
+    children << node.node if node.respond_to?(:node) && node.node
 
     children.any? { |child| ast_uses_clock_function?(child) }
   end

--- a/app/models/types_de_champ/formule_type_de_champ.rb
+++ b/app/models/types_de_champ/formule_type_de_champ.rb
@@ -133,6 +133,13 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
     @type_de_champ.clock_dependent = FormulaCalculationService.clock_dependent?(expression)
     @type_de_champ.state_dependent = FormulaCalculationService.state_dependent?(expression)
 
+    # pf: Calcul des deps structurées (étape D). has_clock est absent ici car
+    # il necessite l'AST Dentaku — il est ajoute plus bas apres construction
+    # de l'AST. Les autres cles (champs, has_state, has_identite) sont
+    # calculees via regex sur l'expression brute, ce qui est sans risque car
+    # les tokens {…} ne peuvent pas apparaitre dans des litteraux Dentaku.
+    @type_de_champ.formule_deps = compute_formule_deps_from_expression(expression)
+
     return if @type_de_champ.formule_expression.blank?
 
     expression = @type_de_champ.formule_expression.strip
@@ -186,6 +193,16 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
     testable = expression.gsub(/\{[^}]+\}/, 'x')
     calculator = FormulaCalculationService.new_calculator
     ast_node = calculator.ast(testable)
+
+    # pf: has_clock est calcule via l'AST (pas via regex) pour eviter les
+    # faux positifs quand un nom de fonction clock apparait dans un litteraal
+    # string. Ex: CONCATENER("AGE(x)", {ref}) → has_clock doit etre absent.
+    # L'AST est deja construit ici, on enrichit formule_deps.
+    if ast_uses_clock_function?(ast_node)
+      deps = @type_de_champ.formule_deps.dup
+      deps['has_clock'] = true
+      @type_de_champ.formule_deps = deps
+    end
 
     # pf: Inférence automatique du type de sortie.
     # Cas spécial : une expression qui est JUSTE une référence nue `{champ}`
@@ -323,5 +340,47 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
     extract_dependent_stable_ids(@type_de_champ.formule_expression)
       .any? { |dep_id| !allowed_stable_ids.include?(dep_id) }
+  end
+
+  # pf: Construit le Hash formule_deps depuis l'expression brute (regex).
+  # has_clock est absent ici — il est ajoute separement via l'AST Dentaku
+  # dans validate_expression, apres construction de l'AST.
+  # Convention : seules les cles vraies sont presentes (sauf 'champs' toujours la).
+  FORMULE_DEPS_TDC_PATTERN = /\{tdc(\d+)(?:\/[^}]+)?\}/
+  FORMULE_DEPS_STATE_PATTERN = /\{dossier_(depose|en_construction|en_instruction|processed)_at\}/
+  FORMULE_DEPS_IDENTITE_PATTERN = /\{(?:individual_|entreprise_)/
+
+  def compute_formule_deps_from_expression(expression)
+    deps = {}
+
+    champs = expression.to_s.scan(FORMULE_DEPS_TDC_PATTERN).map { |m| m[0].to_i }.uniq.sort
+    deps['champs'] = champs
+
+    deps['has_state'] = true if expression.to_s.match?(FORMULE_DEPS_STATE_PATTERN)
+    deps['has_identite'] = true if expression.to_s.match?(FORMULE_DEPS_IDENTITE_PATTERN)
+
+    deps
+  end
+
+  # pf: Fonctions Dentaku dependantes de "maintenant" (clock-dependent).
+  # Detectees via l'AST (pas le regex) pour ne pas matcher les noms de
+  # fonction presents dans des litteraux string.
+  # Rappel : calculator.add_function(:AGE, ...) → node.class.name == :AGE (Symbol).
+  CLOCK_FUNCTION_NAMES = Set[:AUJOURDHUI, :MAINTENANT, :AGE, :EST_PASSEE, :EST_FUTURE].freeze
+
+  # pf: Parcours recursif de l'AST Dentaku pour detecter un appel a une
+  # fonction clock. Les noeuds personnalises (add_function) ont
+  # node.class.name comme Symbol (ex: :AGE) ; les noeuds built-in ont
+  # node.class.name comme String. On s'appuie sur ce discriminant.
+  def ast_uses_clock_function?(node)
+    return false if node.nil?
+    return true if node.class.name.is_a?(Symbol) && CLOCK_FUNCTION_NAMES.include?(node.class.name)
+
+    children = []
+    children.concat(node.args) if node.respond_to?(:args)
+    children << node.left if node.respond_to?(:left) && node.left
+    children << node.right if node.respond_to?(:right) && node.right
+
+    children.any? { |child| ast_uses_clock_function?(child) }
   end
 end

--- a/spec/models/types_de_champ/formule_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/formule_type_de_champ_spec.rb
@@ -477,6 +477,17 @@ describe TypesDeChamp::FormuleTypeDeChamp do
       end
     end
 
+    # pf: non-régression — Dentaku::AST::Negation stocke son opérande dans @node,
+    # pas dans :left/:right. Sans le guard :node, -AGE({tdc42}) retournait
+    # has_clock=false (enfant ignoré silencieusement).
+    context 'with clock function nested under a Negation node' do
+      let(:expression) { '-AGE({tdc42}) + 100' }
+
+      it 'detects clock function nested under a Negation node' do
+        expect(deps['has_clock']).to be(true)
+      end
+    end
+
     context 'with blank expression' do
       let(:expression) { '' }
 
@@ -518,6 +529,23 @@ describe TypesDeChamp::FormuleTypeDeChamp do
           type_de_champ.valid?
           expect(type_de_champ.state_dependent).to be(false)
         end
+      end
+    end
+  end
+
+  # pf: invariant de durabilité — les symboles de CLOCK_FUNCTION_NAMES doivent
+  # correspondre à des fonctions effectivement enregistrées dans le calculateur
+  # Dentaku. Ce test échouera si une fonction est renommée ou supprimée sans
+  # mettre à jour la constante, signalant que le discriminant class.name.is_a?(Symbol)
+  # n'est plus fiable pour cette fonction.
+  describe 'CLOCK_FUNCTION_NAMES invariant' do
+    it 'all clock function names are registered in the Dentaku calculator' do
+      calc = FormulaCalculationService.new_calculator
+      registry = calc.instance_variable_get(:@function_registry)
+      TypesDeChamp::FormuleTypeDeChamp::CLOCK_FUNCTION_NAMES.each do |sym|
+        klass = registry.get(sym)
+        expect(klass).not_to be_nil, "#{sym} is listed in CLOCK_FUNCTION_NAMES but not registered in the calculator"
+        expect(klass.name).to eq(sym), "#{sym} registered class name mismatch: expected #{sym.inspect}, got #{klass.name.inspect}"
       end
     end
   end

--- a/spec/models/types_de_champ/formule_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/formule_type_de_champ_spec.rb
@@ -380,4 +380,145 @@ describe TypesDeChamp::FormuleTypeDeChamp do
       expect(formule_type_de_champ.estimated_fill_duration(revision)).to eq(0.seconds)
     end
   end
+
+  # pf: formule_deps est un Hash structuré stocké dans options['formule_deps']
+  # calculé à chaque validation. Il remplace conceptuellement les flags booléens
+  # clock_dependent / state_dependent (qui restent écrits pour compatibilité
+  # ascendante jusqu'à l'étape F). Convention : clés absentes <=> false.
+  describe 'formule_deps computation' do
+    subject(:deps) do
+      type_de_champ.valid?
+      type_de_champ.options['formule_deps']
+    end
+
+    context 'with a single tdc reference' do
+      let(:expression) { '{tdc42}' }
+
+      it 'stores the stable_id in champs, no other keys' do
+        expect(deps).to eq('champs' => [42])
+      end
+    end
+
+    context 'with duplicate tdc references' do
+      let(:expression) { '{tdc42} + {tdc78} + {tdc42}' }
+
+      it 'deduplicates and sorts the stable_ids' do
+        expect(deps['champs']).to eq([42, 78])
+      end
+    end
+
+    context 'with a path suffix in the tdc reference' do
+      let(:expression) { '{tdc42/nom}' }
+
+      it 'strips the path and stores only the stable_id' do
+        expect(deps['champs']).to eq([42])
+      end
+    end
+
+    context 'with AUJOURDHUI() (clock function)' do
+      let(:expression) { 'AUJOURDHUI() + DUREE_JOURS(7)' }
+
+      it 'sets has_clock, no champs' do
+        expect(deps['has_clock']).to be(true)
+        expect(deps['champs']).to eq([])
+      end
+    end
+
+    # pf: BUG cible de l'étape D — REGEX matche "AGE(" dans un littéral string,
+    # l'AST ne le fait pas. Ce test garantit que la détection via l'AST est
+    # correcte et que le regex naïf n'est PAS utilisé pour has_clock.
+    context 'with AGE inside a string literal (not a function call)' do
+      let(:expression) { 'CONCATENER("AGE(x) literal", {tdc42})' }
+
+      it 'does not set has_clock (AGE inside string does not count)' do
+        expect(deps).not_to have_key('has_clock')
+      end
+
+      it 'still captures the tdc reference' do
+        expect(deps['champs']).to eq([42])
+      end
+    end
+
+    context 'with a dossier state timestamp reference' do
+      let(:expression) { '{dossier_depose_at}' }
+
+      it 'sets has_state' do
+        expect(deps['has_state']).to be(true)
+        expect(deps['champs']).to eq([])
+      end
+    end
+
+    context 'with individual identity reference' do
+      let(:expression) { '{individual_last_name}' }
+
+      it 'sets has_identite' do
+        expect(deps['has_identite']).to be(true)
+        expect(deps['champs']).to eq([])
+      end
+    end
+
+    context 'with entreprise identity reference' do
+      let(:expression) { '{entreprise_siret}' }
+
+      it 'sets has_identite' do
+        expect(deps['has_identite']).to be(true)
+        expect(deps['champs']).to eq([])
+      end
+    end
+
+    context 'with mixed champ reference, clock function, no state/identite' do
+      let(:expression) { 'SI(AGE({tdc42}) > 18, "OK", "KO")' }
+
+      it 'captures champ and clock, but not state or identite' do
+        expect(deps['champs']).to eq([42])
+        expect(deps['has_clock']).to be(true)
+        expect(deps).not_to have_key('has_state')
+        expect(deps).not_to have_key('has_identite')
+      end
+    end
+
+    context 'with blank expression' do
+      let(:expression) { '' }
+
+      it 'stores only the champs key with empty array' do
+        expect(deps).to eq('champs' => [])
+      end
+    end
+
+    # pf: non-régression — les flags clock_dependent et state_dependent doivent
+    # continuer à être écrits (compatibilité avec les consommateurs étape F).
+    context 'non-regression: existing flags still written' do
+      context 'clock_dependent with AUJOURDHUI' do
+        let(:expression) { 'AUJOURDHUI()' }
+
+        it 'still sets clock_dependent on the type_de_champ' do
+          type_de_champ.valid?
+          expect(type_de_champ.clock_dependent).to be(true)
+        end
+      end
+
+      context 'state_dependent with dossier timestamp' do
+        let(:expression) { '{dossier_en_instruction_at}' }
+
+        it 'still sets state_dependent on the type_de_champ' do
+          type_de_champ.valid?
+          expect(type_de_champ.state_dependent).to be(true)
+        end
+      end
+
+      context 'no clock, no state' do
+        let(:expression) { '1 + 1' }
+
+        it 'clock_dependent is false' do
+          type_de_champ.valid?
+          expect(type_de_champ.clock_dependent).to be(false)
+        end
+
+        it 'state_dependent is false' do
+          type_de_champ.valid?
+          expect(type_de_champ.state_dependent).to be(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Étape D du chantier **formule typage + dépendances** ([design doc](docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md) + [ajustements](docs/superpowers/specs/2026-05-21-formule-typage-dependances-ajustements.md)).

Introduit un graphe de dépendances unifié pour les formules sous forme de Hash structuré dans `options['formule_deps']`. **Additif uniquement** : les anciens flags `clock_dependent` / `state_dependent` continuent d'être écrits, les consommateurs migreront en étape F.

### Format

```ruby
options['formule_deps'] = {
  'champs'       => [42, 78],   # Array<Integer> stable_ids référencés (dedup, sorted)
  'has_clock'    => true,       # uses date functions tied to "now" (AUJOURDHUI, AGE, ...)
  'has_state'    => true,       # references {dossier_*_at}
  'has_identite' => true        # references {individual_*} or {entreprise_*}
}
```

Convention : clé absente ⇒ false. Seuls les flags vrais sont stockés. `champs` toujours présent (Array vide si pas de ref).

### Décisions de design

- **`has_clock` via AST Dentaku, pas regex** (Aj-2 de la revue critique). Une regex `/AGE|AUJOURDHUI/` matche aussi à l'intérieur d'un littéral string (ex: `CONCATENER("L'AGE(x)", {Nom})`), ce qui déclencherait des recalculs quotidiens à tort. L'AST distingue les vrais appels de fonction.
- **Autres flags via regex** sur l'expression brute : `{}` sont des délimiteurs syntaxiques Dentaku, jamais dans un littéral, regex sûre par construction.
- **Path stripping sur `champs`** : `{tdc42/nom}` ⇒ `42` (le path n'a pas de consommateur identifié).

### Robustesse

- Walker AST traite les nœuds `Negation` (issue trouvée en code review : `-AGE(x)` aurait été manqué).
- Test invariant : vérifie que les 5 fonctions clock sont effectivement enregistrées dans le registre Dentaku et que leur nom de classe correspond aux symboles attendus → fait fail loudly si Dentaku change son API.

### Scope hors PR

- Étape E (migration data — écrire `formule_deps` sur les TDC existants) : PR suivante.
- Étape F (migration des 5 consommateurs vers `formule_deps`, suppression des anciens flags) : PR suivante.
- Étape G (triggers `identite` côté controllers) : PR suivante.

## Test plan

- [x] 13 nouveaux scenarios dans `formule_type_de_champ_spec.rb` couvrant les 4 catégories de dépendances + le cas anti-régression `CONCATENER("AGE(x) literal", {tdc42})` (AST vs regex) + Negation
- [x] 56/56 specs verts : `bundle exec rspec spec/models/types_de_champ/formule_type_de_champ_spec.rb`
- [x] Rubocop vert sur les fichiers touchés
- [x] Anciens flags `clock_dependent` / `state_dependent` toujours écrits — non-régression de l'existant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
