### PR TITLE
refactor(formule): migrer les consommateurs vers formule_deps (étape F)

### DIFF
--- a/app/jobs/cron/refresh_clock_dependent_formulas_job.rb
+++ b/app/jobs/cron/refresh_clock_dependent_formulas_job.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-# pf: Job quotidien qui recalcule les formules clock_dependent sur les dossiers
-# actifs. Scope :
-#   - brouillons : toutes les formules clock_dependent (publiques + privées).
+# pf: Job quotidien qui recalcule les formules avec formule_deps['has_clock'] = true
+# sur les dossiers actifs. Scope :
+#   - brouillons : toutes les formules clock-dépendantes (publiques + privées).
 #     Les formules publiques y sont dynamiques pour que l'usager qui revient
 #     sur un brouillon voie un AGE à jour.
 #   - dossiers en_construction / en_instruction / pending_correction : les
-#     annotations privées clock_dependent uniquement. Les formules publiques
+#     annotations privées clock-dépendantes uniquement. Les formules publiques
 #     y sont figées (la valeur au dépôt reflète la demande au dépôt).
 #
 # Les dossiers terminaux (accepte/refuse/sans_suite) ne sont jamais touchés.
 #
 # Pour limiter la charge : on filtre au niveau SQL les révisions qui contiennent
-# au moins un TDC formule clock_dependent, puis on enqueue un RefreshClock
-# DependentFormulasDossierJob par dossier (parallélisation + isolation des
-# erreurs par dossier).
+# au moins un TDC formule avec formule_deps['has_clock'] = true, puis on enqueue
+# un RefreshClockDependentFormulasDossierJob par dossier (parallélisation +
+# isolation des erreurs par dossier).
 class Cron::RefreshClockDependentFormulasJob < Cron::CronJob
   self.schedule_expression = "every day at 00:10"
 
@@ -38,7 +38,7 @@ class Cron::RefreshClockDependentFormulasJob < Cron::CronJob
     ProcedureRevisionTypeDeChamp
       .joins(:type_de_champ)
       .where(types_de_champ: { type_champ: 'formule' })
-      .where("types_de_champ.options->>'clock_dependent' = 'true'")
+      .where("types_de_champ.options->'formule_deps'->>'has_clock' = 'true'")
       .distinct
       .pluck(:revision_id)
   end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -350,7 +350,7 @@ class Champ < ApplicationRecord
     # stable_id source → [stable_ids des formules qui en dépendent]
     deps_graph = Hash.new { |h, k| h[k] = Set.new }
     formula_tdcs.each do |tdc|
-      tdc.dependent_stable_ids.each { |dep_sid| deps_graph[dep_sid].add(tdc.stable_id) }
+      (tdc.formule_deps&.[]('champs') || []).each { |dep_sid| deps_graph[dep_sid].add(tdc.stable_id) }
     end
 
     # BFS topologique depuis self.stable_id
@@ -394,7 +394,7 @@ class Champ < ApplicationRecord
   def dependent_formula_champs_from(all_champs)
     all_champs.filter do |formula_champ|
       next false if formula_champ.stable_id.nil?
-      next false unless formula_champ.formule? && formula_champ.type_de_champ.dependent_stable_ids&.include?(stable_id)
+      next false unless formula_champ.formule? && (formula_champ.type_de_champ.formule_deps&.[]('champs') || []).include?(stable_id)
 
       if row_id.present?
         formula_champ.row_id == row_id || formula_champ.row_id.nil?

--- a/app/models/concerns/dossier_formula_refresh_concern.rb
+++ b/app/models/concerns/dossier_formula_refresh_concern.rb
@@ -5,13 +5,13 @@
 # Deux familles de dépendances nécessitent des recalculs hors du flow normal
 # (le flow normal = cascade sur save d'un champ source) :
 #
-#   1. **clock_dependent** : formules qui utilisent AUJOURDHUI/MAINTENANT/
+#   1. **formule_deps['has_clock']** : formules qui utilisent AUJOURDHUI/MAINTENANT/
 #      AGE/EST_PASSEE/EST_FUTURE — leur valeur change avec le temps qui
 #      passe. Recalcul quotidien via Cron::RefreshClockDependentFormulasJob,
 #      scopé par état (brouillon → public+privé, actif non-brouillon →
 #      privé seulement).
 #
-#   2. **state_dependent** : formules qui référencent les timestamps d'état
+#   2. **formule_deps['has_state']** : formules qui référencent les timestamps d'état
 #      du dossier ({dossier_depose_at}, {dossier_en_instruction_at}, etc.).
 #      Ces valeurs changent à chaque transition. Recalcul synchrone via
 #      les hooks after_commit_passer_en_*, sans distinction public/privé
@@ -20,7 +20,7 @@ module DossierFormulaRefreshConcern
   extend ActiveSupport::Concern
 
   # pf: Timestamps d'état du dossier qui, s'ils changent, peuvent faire
-  # bouger la valeur d'une formule state_dependent.
+  # bouger la valeur d'une formule avec formule_deps['has_state'] = true.
   STATE_TIMESTAMP_COLUMNS = [:depose_at, :en_construction_at, :en_instruction_at, :processed_at].freeze
 
   included do
@@ -28,23 +28,23 @@ module DossierFormulaRefreshConcern
     # pour isoler le changement dans ce concern et éviter d'éditer
     # dossier_state_concern à chaque ajout d'un nouveau trigger. Filtré par
     # un changement effectif de timestamp d'état + présence d'au moins une
-    # formule state_dependent.
+    # formule avec formule_deps['has_state'] = true.
     after_commit :refresh_state_dependent_formulas_if_needed, on: :update
   end
 
-  # pf: Recalcule les formules state_dependent après une transition d'état.
+  # pf: Recalcule les formules avec formule_deps['has_state'] = true après une transition d'état.
   # Appelée depuis les callbacks after_commit_passer_en_* de Dossier.
   def refresh_state_dependent_formulas
-    refresh_formulas_matching(&:state_dependent)
+    refresh_formulas_matching { |tdc| tdc.formule_deps&.[]('has_state') }
   end
 
-  # pf: Recalcule les formules clock_dependent selon le scope fourni.
+  # pf: Recalcule les formules avec formule_deps['has_clock'] = true selon le scope fourni.
   # scope: :all → publiques + privées (pour dossiers en brouillon)
   # scope: :private_only → annotations privées uniquement (pour dossiers
   # actifs déposés, où les formules publiques sont figées)
   def refresh_clock_dependent_formulas(scope: :all)
     refresh_formulas_matching do |tdc|
-      next false unless tdc.clock_dependent
+      next false unless tdc.formule_deps&.[]('has_clock')
       scope == :private_only ? tdc.private? : true
     end
   end
@@ -209,7 +209,7 @@ module DossierFormulaRefreshConcern
   end
 
   def has_state_dependent_formula?
-    revision&.types_de_champ&.any? { |tdc| tdc.formule? && tdc.state_dependent }
+    revision&.types_de_champ&.any? { |tdc| tdc.formule? && tdc.formule_deps&.[]('has_state') }
   end
 
   # pf: Boucle générique de recalcul. Utilise update_column pour éviter de

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -226,7 +226,7 @@ class ProcedureRevision < ApplicationRecord
     (tdc.public? ? types_de_champ_public : types_de_champ_private).filter do |other_tdc|
       next if !other_tdc.formule?
 
-      other_tdc.dependent_stable_ids.include?(stable_id)
+      (other_tdc.formule_deps&.[]('champs') || []).include?(stable_id)
     end
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -146,7 +146,7 @@ class TypeDeChamp < ApplicationRecord
     te_fenua: [:parcelles, :batiments, :zones_manuelles, :te_fenua_layer],
     lexpol: [:lexpol_modele, :lexpol_mapping],
     visa: [:accredited_users],
-    formule: [:formule_expression, :dependent_stable_ids, :formule_output_type, :clock_dependent, :state_dependent, :formule_deps],
+    formule: [:formule_expression, :formule_output_type, :formule_deps],
   }
   INSTANCE_OPTIONS = INSTANCE_OPTIONS_BY_TYPE.values.reduce(&:+).uniq
   INSTANCE_CHAMPS_PARAMS = [:numero_dn, :date_de_naissance]
@@ -461,24 +461,6 @@ class TypeDeChamp < ApplicationRecord
         formule_expression
       end
     )
-  end
-
-  def dependent_stable_ids
-    return [] unless formule?
-    # pf: Extract stable_ids from column references in the expression
-    stable_ids = []
-
-    formule_expression.to_s.scan(/\{([^}]+)\}/).each do |match|
-      ref = match[0].strip
-
-      if ref.match?(/^tdc(\d+)/)
-        stable_ids << ref.match(/^tdc(\d+)/)[1].to_i
-      elsif ref.match?(/^\d+$/)
-        stable_ids << ref.to_i
-      end
-    end
-
-    stable_ids.uniq
   end
 
   # pf: Returns champs that can be referenced by this formula field

--- a/app/models/types_de_champ/formule_type_de_champ.rb
+++ b/app/models/types_de_champ/formule_type_de_champ.rb
@@ -124,25 +124,17 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
   end
 
   def validate_expression
-    # pf: Met à jour les flags clock_dependent / state_dependent à chaque
-    # validation — permettent au RefreshFormulasJob (clock) et aux hooks de
-    # transition d'état (state) de cibler efficacement les formules à
-    # recalculer. Fait avant le return early pour que l'expression vide
-    # remette les flags à false.
-    expression = @type_de_champ.formule_expression
-    @type_de_champ.clock_dependent = FormulaCalculationService.clock_dependent?(expression)
-    @type_de_champ.state_dependent = FormulaCalculationService.state_dependent?(expression)
-
     # pf: Calcul des deps structurées (étape D). has_clock est absent ici car
     # il necessite l'AST Dentaku — il est ajoute plus bas apres construction
     # de l'AST. Les autres cles (champs, has_state, has_identite) sont
     # calculees via regex sur l'expression brute, ce qui est sans risque car
     # les tokens {…} ne peuvent pas apparaitre dans des litteraux Dentaku.
-    @type_de_champ.formule_deps = compute_formule_deps_from_expression(expression)
+    raw_expression = @type_de_champ.formule_expression
+    @type_de_champ.formule_deps = compute_formule_deps_from_expression(raw_expression)
 
-    return if @type_de_champ.formule_expression.blank?
+    return if raw_expression.blank?
 
-    expression = @type_de_champ.formule_expression.strip
+    expression = raw_expression.strip
 
     if expression.length > 1000
       @type_de_champ.errors.add(:formule_expression, :too_long, count: 1000)
@@ -346,18 +338,24 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
   # has_clock est absent ici — il est ajoute separement via l'AST Dentaku
   # dans validate_expression, apres construction de l'AST.
   # Convention : seules les cles vraies sont presentes (sauf 'champs' toujours la).
+  # Supporte les deux formats : {tdc123} (format courant) et {123} (ancien format
+  # de compatibilite ascendante), ainsi que le chemin optionnel {tdc123/path}.
   FORMULE_DEPS_TDC_PATTERN = /\{tdc(\d+)(?:\/[^}]+)?\}/
+  FORMULE_DEPS_LEGACY_PATTERN = /\{(\d+)\}/
   FORMULE_DEPS_STATE_PATTERN = /\{dossier_(depose|en_construction|en_instruction|processed)_at\}/
   FORMULE_DEPS_IDENTITE_PATTERN = /\{(?:individual_|entreprise_)/
 
   def compute_formule_deps_from_expression(expression)
     deps = {}
 
-    champs = expression.to_s.scan(FORMULE_DEPS_TDC_PATTERN).map { |m| m[0].to_i }.uniq.sort
+    expr_str = expression.to_s
+    tdc_ids = expr_str.scan(FORMULE_DEPS_TDC_PATTERN).map { |m| m[0].to_i }
+    legacy_ids = expr_str.scan(FORMULE_DEPS_LEGACY_PATTERN).map { |m| m[0].to_i }
+    champs = (tdc_ids + legacy_ids).uniq.sort
     deps['champs'] = champs
 
-    deps['has_state'] = true if expression.to_s.match?(FORMULE_DEPS_STATE_PATTERN)
-    deps['has_identite'] = true if expression.to_s.match?(FORMULE_DEPS_IDENTITE_PATTERN)
+    deps['has_state'] = true if expr_str.match?(FORMULE_DEPS_STATE_PATTERN)
+    deps['has_identite'] = true if expr_str.match?(FORMULE_DEPS_IDENTITE_PATTERN)
 
     deps
   end

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -187,33 +187,6 @@ class FormulaCalculationService
     end
   end
 
-  # pf: Pattern de détection des fonctions qui dépendent de l'instant présent
-  # (i.e. qui renvoient une valeur différente au fil du temps sans qu'aucun
-  # champ source n'ait changé). Utilisé par le TDC pour marquer la formule,
-  # et par RefreshFormulasJob pour cibler les formules à recalculer à minuit.
-  # AGE/EST_PASSEE/EST_FUTURE dépendent implicitement de Date.current.
-  # JOUR/MOIS/ANNEE/JOURSEM ne sont PAS clock-dependent (dépendent uniquement
-  # de leur argument).
-  CLOCK_DEPENDENT_PATTERN = /\b(AUJOURDHUI|MAINTENANT|AGE|EST_PASSEE|EST_FUTURE)\s*\(/
-
-  def self.clock_dependent?(expression)
-    return false if expression.blank?
-    expression.match?(CLOCK_DEPENDENT_PATTERN)
-  end
-
-  # pf: Pattern de détection des références aux timestamps d'état du dossier.
-  # Ces valeurs changent à chaque transition (depose_at au dépôt,
-  # en_instruction_at au passage en instruction, etc.), et nécessitent donc
-  # un recalcul synchrone au moment de la transition — le job quotidien
-  # créerait un lag max 24h inacceptable pour des formules type "jours en
-  # instruction".
-  STATE_DEPENDENT_PATTERN = /\{dossier_(depose|en_construction|en_instruction|processed)_at\}/
-
-  def self.state_dependent?(expression)
-    return false if expression.blank?
-    expression.match?(STATE_DEPENDENT_PATTERN)
-  end
-
   private
 
   def create_calculator

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -787,7 +787,7 @@ describe Champ do
       end
     end
 
-    context 'when dependent_stable_ids is nil' do
+    context 'when formule has no champ dependencies' do
       let!(:formule_tdc_without_deps) do
         create(:type_de_champ_formule,
           procedure: procedure,

--- a/spec/models/champs/formule_cascade_audit_spec.rb
+++ b/spec/models/champs/formule_cascade_audit_spec.rb
@@ -22,7 +22,11 @@ RSpec.describe 'Formule cascade refresh_formulas_after', type: :model do
   end
 
   def set_formule_expression(dossier, formule_tdc, expression)
-    formule_tdc.update_column(:options, formule_tdc.options.merge('formule_expression' => expression))
+    # pf: passe par update! (avec validation) pour que formule_deps soit recalculé
+    # en même temps que formule_expression — update_column bypasse les callbacks
+    # et laisserait formule_deps stale, ce qui romprait la construction du graphe
+    # de dépendances via formule_deps['champs'].
+    formule_tdc.update!(formule_expression: expression)
   end
 
   def find_champ(dossier, tdc)

--- a/spec/models/concerns/dossier_formula_refresh_concern_spec.rb
+++ b/spec/models/concerns/dossier_formula_refresh_concern_spec.rb
@@ -17,15 +17,15 @@ describe DossierFormulaRefreshConcern do
     formule_tdc.reload
   end
 
-  describe 'flags on the type_de_champ' do
-    it 'marks the formula as clock_dependent' do
+  describe 'formule_deps on the type_de_champ' do
+    it "sets formule_deps['has_clock'] for a clock-dependent formula" do
       formule_tdc = revision.types_de_champ.find(&:formule?)
-      expect(formule_tdc.clock_dependent).to be true
+      expect(formule_tdc.formule_deps&.[]('has_clock')).to be true
     end
 
-    it 'marks the formula as state_dependent' do
+    it "sets formule_deps['has_state'] for a state-dependent formula" do
       formule_tdc = revision.types_de_champ.find(&:formule?)
-      expect(formule_tdc.state_dependent).to be true
+      expect(formule_tdc.formule_deps&.[]('has_state')).to be true
     end
   end
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -882,44 +882,49 @@ describe TypeDeChamp do
       end
     end
 
-    # pf: Tests for dependent_stable_ids with new format
-    describe '#dependent_stable_ids with new format' do
+    # pf: Tests for formule_deps['champs'] (replaces removed dependent_stable_ids)
+    describe "formule_deps['champs']" do
       let(:formule_tdc) { build(:type_de_champ_formule) }
+
+      def champs_for(tdc)
+        tdc.valid?
+        tdc.formule_deps&.[]('champs') || []
+      end
 
       it 'extracts stable_ids from {tdc456} format' do
         formule_tdc.formule_expression = '{tdc456} + {tdc789}'
 
-        expect(formule_tdc.dependent_stable_ids).to contain_exactly(456, 789)
+        expect(champs_for(formule_tdc)).to contain_exactly(456, 789)
       end
 
       it 'extracts stable_ids from {tdc456/path} format' do
         formule_tdc.formule_expression = '{tdc123/commune} + {tdc456/date_de_naissance}'
 
-        expect(formule_tdc.dependent_stable_ids).to contain_exactly(123, 456)
+        expect(champs_for(formule_tdc)).to contain_exactly(123, 456)
       end
 
       it 'supports old format {123} (backward compatibility)' do
         formule_tdc.formule_expression = '{123} + {456}'
 
-        expect(formule_tdc.dependent_stable_ids).to contain_exactly(123, 456)
+        expect(champs_for(formule_tdc)).to contain_exactly(123, 456)
       end
 
       it 'supports mixed format {123} + {tdc456}' do
         formule_tdc.formule_expression = '{123} + {tdc456}'
 
-        expect(formule_tdc.dependent_stable_ids).to contain_exactly(123, 456)
+        expect(champs_for(formule_tdc)).to contain_exactly(123, 456)
       end
 
       it 'ignores system columns {dossier_number}' do
         formule_tdc.formule_expression = '{dossier_number} + {tdc456}'
 
-        expect(formule_tdc.dependent_stable_ids).to contain_exactly(456)
+        expect(champs_for(formule_tdc)).to contain_exactly(456)
       end
 
       it 'extracts from complex expressions with functions' do
         formule_tdc.formule_expression = 'SI({tdc123} > 10, SOMME({tdc456}, {tdc789}), 0)'
 
-        expect(formule_tdc.dependent_stable_ids).to contain_exactly(123, 456, 789)
+        expect(champs_for(formule_tdc)).to contain_exactly(123, 456, 789)
       end
     end
   end

--- a/spec/models/types_de_champ/formule_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/formule_type_de_champ_spec.rb
@@ -382,9 +382,8 @@ describe TypesDeChamp::FormuleTypeDeChamp do
   end
 
   # pf: formule_deps est un Hash structuré stocké dans options['formule_deps']
-  # calculé à chaque validation. Il remplace conceptuellement les flags booléens
-  # clock_dependent / state_dependent (qui restent écrits pour compatibilité
-  # ascendante jusqu'à l'étape F). Convention : clés absentes <=> false.
+  # calculé à chaque validation. Il remplace les anciens flags booléens
+  # clock_dependent / state_dependent (supprimés à l'étape F). Convention : clés absentes <=> false.
   describe 'formule_deps computation' do
     subject(:deps) do
       type_de_champ.valid?
@@ -496,38 +495,38 @@ describe TypesDeChamp::FormuleTypeDeChamp do
       end
     end
 
-    # pf: non-régression — les flags clock_dependent et state_dependent doivent
-    # continuer à être écrits (compatibilité avec les consommateurs étape F).
-    context 'non-regression: existing flags still written' do
-      context 'clock_dependent with AUJOURDHUI' do
+    # pf: non-régression — formule_deps doit couvrir les cas has_clock et has_state
+    # (les anciens flags clock_dependent / state_dependent ont été supprimés à l'étape F).
+    context 'non-regression: formule_deps covers clock and state detection' do
+      context "AUJOURDHUI() sets has_clock" do
         let(:expression) { 'AUJOURDHUI()' }
 
-        it 'still sets clock_dependent on the type_de_champ' do
+        it "sets formule_deps['has_clock'] to true" do
           type_de_champ.valid?
-          expect(type_de_champ.clock_dependent).to be(true)
+          expect(type_de_champ.formule_deps&.[]('has_clock')).to be(true)
         end
       end
 
-      context 'state_dependent with dossier timestamp' do
+      context "dossier timestamp reference sets has_state" do
         let(:expression) { '{dossier_en_instruction_at}' }
 
-        it 'still sets state_dependent on the type_de_champ' do
+        it "sets formule_deps['has_state'] to true" do
           type_de_champ.valid?
-          expect(type_de_champ.state_dependent).to be(true)
+          expect(type_de_champ.formule_deps&.[]('has_state')).to be(true)
         end
       end
 
       context 'no clock, no state' do
         let(:expression) { '1 + 1' }
 
-        it 'clock_dependent is false' do
+        it "does not set formule_deps['has_clock']" do
           type_de_champ.valid?
-          expect(type_de_champ.clock_dependent).to be(false)
+          expect(type_de_champ.formule_deps).not_to have_key('has_clock')
         end
 
-        it 'state_dependent is false' do
+        it "does not set formule_deps['has_state']" do
           type_de_champ.valid?
-          expect(type_de_champ.state_dependent).to be(false)
+          expect(type_de_champ.formule_deps).not_to have_key('has_state')
         end
       end
     end


### PR DESCRIPTION
## Summary

Étape F du chantier **formule typage + dépendances** ([design doc](docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md) + [ajustements](docs/superpowers/specs/2026-05-21-formule-typage-dependances-ajustements.md)).

Migre tous les consommateurs des anciens flags (`clock_dependent`, `state_dependent`, `dependent_stable_ids`) vers le nouveau `options['formule_deps']` introduit en étape D (PR #444). Supprime ensuite le code mort.

**PR stackée sur #444** (étape D). Quand #444 mergera dans devpf, GitHub repointera automatiquement la base de cette PR.

### Sites migrés (5 consommateurs)

| Fichier | Avant | Après |
|---|---|---|
| `champ.rb` (×2) | `tdc.dependent_stable_ids.each` | `(tdc.formule_deps&.[]('champs') \|\| []).each` |
| `dossier_formula_refresh_concern.rb` (×3) | `tdc.clock_dependent` / `tdc.state_dependent` | `tdc.formule_deps&.[]('has_clock')` / `[has_state]` |
| `cron/refresh_clock_dependent_formulas_job.rb` | `options->>'clock_dependent' = 'true'` | `options->'formule_deps'->>'has_clock' = 'true'` |
| `procedure_revision.rb` | `other_tdc.dependent_stable_ids.include?(stable_id)` | `(other_tdc.formule_deps&.[]('champs') \|\| []).include?(stable_id)` |

### Code mort supprimé

- `TypeDeChamp#dependent_stable_ids` (méthode d'instance, ne re-parse plus l'expression à chaque appel)
- `FormulaCalculationService.clock_dependent?` + `state_dependent?` (méthodes de classe)
- `FormulaCalculationService::CLOCK_DEPENDENT_PATTERN` + `STATE_DEPENDENT_PATTERN` (constantes)
- Écritures `@type_de_champ.clock_dependent = ...` / `state_dependent = ...` dans `validate_expression`
- Entries `:clock_dependent`, `:state_dependent`, `:dependent_stable_ids` du whitelist `INSTANCE_OPTIONS_BY_TYPE[:formule]`

### Bug corrigé (bonus)

`compute_formule_deps_from_expression` (étape D) ne supportait que `{tdc42}`, mais l'ancien `TypeDeChamp#dependent_stable_ids` supportait aussi `{42}` (format legacy). Ajout de `FORMULE_DEPS_LEGACY_PATTERN` pour préserver le comportement.

### Scope hors PR

- Étape G (triggers identité côté controllers)
- Scénarios système S1-S4 (en fin de chantier)
- Cleanup nommage public (`refresh_clock_dependent_formulas`, `has_state_dependent_formula?` etc. conservent leur nom pour stabilité d'API interne)

## Test plan

- [x] 466 specs verts sur l'ensemble des fichiers touchés et de leur voisinage
- [x] Cron SQL vérifiée : `options->'formule_deps'->>'has_clock' = 'true'` matche bien les TDC avec `has_clock: true`
- [x] Rubocop vert sur les 12 fichiers touchés
- [x] Aucune référence résiduelle aux anciens flags en tant qu'attributs stockés (les noms de méthodes wrapper sont conservés intentionnellement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
