### PR TITLE
feat(formule): trigger recalcul has_identite côté controller (étape G)

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -188,6 +188,7 @@ module Users
         end
 
         @dossier.update!(autorisation_donnees: true, identity_updated_at: Time.zone.now)
+        @dossier.refresh_formulas_with_identite_dependents
 
         flash.notice = t('.identity_saved')
 
@@ -618,6 +619,7 @@ module Users
 
       current_user.update!(siret: siret)
       @dossier.update!(autorisation_donnees: true, last_champ_updated_at: Time.zone.now)
+      @dossier.refresh_formulas_with_identite_dependents
       redirect_to etablissement_dossier_path
     end
 

--- a/app/models/concerns/dossier_formula_refresh_concern.rb
+++ b/app/models/concerns/dossier_formula_refresh_concern.rb
@@ -38,6 +38,20 @@ module DossierFormulaRefreshConcern
     refresh_formulas_matching { |tdc| tdc.formule_deps&.[]('has_state') }
   end
 
+  # pf: Recalcule les formules qui référencent l'identité du déclarant
+  # (champs {individual_*} ou {entreprise_*}). Appelé explicitement par les
+  # controllers après modification de l'identité — pas de callback AR sur
+  # Individual/Etablissement pour respecter la convention "cascade explicite"
+  # documentée dans CLAUDE.md.
+  def refresh_formulas_with_identite_dependents
+    matching = revision.types_de_champ.filter do |tdc|
+      tdc.formule? && tdc.formule_deps&.[]('has_identite')
+    end
+    return if matching.empty?
+
+    compute_formulas_in_order(only: matching.map(&:stable_id).to_set)
+  end
+
   # pf: Recalcule les formules avec formule_deps['has_clock'] = true selon le scope fourni.
   # scope: :all → publiques + privées (pour dossiers en brouillon)
   # scope: :private_only → annotations privées uniquement (pour dossiers

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -312,6 +312,36 @@ describe Users::DossiersController, type: :controller do
         end
       end
     end
+
+    context 'when the dossier has a formula referencing {individual_last_name}' do
+      let(:procedure) {
+        create(:procedure, :published, :for_individual, types_de_champ_private: [
+          { type: :formule, libelle: 'Formule nom' },
+        ])
+      }
+      let(:dossier) { create(:dossier, :with_individual, user: user, procedure: procedure) }
+      let(:dossier_params) { { individual_attributes: { gender: 'M', nom: 'Martin', prenom: 'Jean' } } }
+
+      before do
+        formule_tdc = procedure.active_revision.types_de_champ.find(&:formule?)
+        expr, _ = FormulaExpressionService.convert_to_stable_ids(
+          'CONCATENER("Bonjour ", {individual_last_name})',
+          procedure.active_revision
+        )
+        formule_tdc.update!(formule_expression: expr)
+        dossier.individual.update!(nom: 'Dupont')
+        dossier.compute_formulas_in_order
+        sign_in(user)
+      end
+
+      it 'recomputes the formula after identity update' do
+        post :update_identite, params: { id: dossier.id, dossier: dossier_params }
+
+        formule_champ = dossier.project_champs_private.find { |c| c.libelle == 'Formule nom' }
+        # Individual#nom is stored uppercased
+        expect(formule_champ.reload.value).to eq('Bonjour MARTIN')
+      end
+    end
   end
 
   describe '#siret' do

--- a/spec/models/concerns/dossier_formula_refresh_concern_spec.rb
+++ b/spec/models/concerns/dossier_formula_refresh_concern_spec.rb
@@ -43,6 +43,83 @@ describe DossierFormulaRefreshConcern do
     end
   end
 
+  describe '#refresh_formulas_with_identite_dependents' do
+    let(:individual_procedure) {
+      create(:procedure, :published, :for_individual, types_de_champ_private: [
+        { type: :formule, libelle: 'Formule identite' },
+        { type: :formule, libelle: 'Formule horloge' },
+      ])
+    }
+    let(:individual_revision) { individual_procedure.active_revision }
+    let(:individual_dossier) {
+      create(:dossier, :with_individual, :en_construction, procedure: individual_procedure)
+    }
+
+    before do
+      identite_tdc = individual_revision.types_de_champ.find { |t| t.formule? && t.libelle == 'Formule identite' }
+      clock_tdc    = individual_revision.types_de_champ.find { |t| t.formule? && t.libelle == 'Formule horloge' }
+
+      # formula with has_identite: true
+      identite_expr, _ = FormulaExpressionService.convert_to_stable_ids(
+        'CONCATENER("Bonjour ", {individual_last_name})',
+        individual_revision
+      )
+      identite_tdc.update!(formule_expression: identite_expr)
+
+      # formula without has_identite (only clock dep)
+      clock_expr, _ = FormulaExpressionService.convert_to_stable_ids('AUJOURDHUI()', individual_revision)
+      clock_tdc.update!(formule_expression: clock_expr)
+
+      # Materialize initial formula champs
+      individual_dossier.compute_formulas_in_order
+      individual_dossier.reload
+    end
+
+    it 'recomputes formulas with has_identite: true after identity change' do
+      individual_dossier.individual.update!(nom: 'Martin')
+      individual_dossier.send(:reset_champs_cache)
+      individual_dossier.refresh_formulas_with_identite_dependents
+
+      identite_champ = individual_dossier.project_champs_private.find { |c| c.libelle == 'Formule identite' }
+      # Individual#nom is stored uppercased — match the actual stored value
+      expect(identite_champ.reload.value).to eq('Bonjour MARTIN')
+    end
+
+    it 'does NOT recompute formulas without has_identite' do
+      # Force the clock formula to a known value first
+      clock_champ = individual_dossier.project_champs_private.find { |c| c.libelle == 'Formule horloge' }
+      frozen_value = clock_champ.reload.value
+
+      travel_to(2.days.from_now) do
+        individual_dossier.individual.update!(nom: 'Durand')
+        individual_dossier.send(:reset_champs_cache)
+        individual_dossier.refresh_formulas_with_identite_dependents
+      end
+
+      # Clock formula should NOT have been updated (no has_identite)
+      expect(clock_champ.reload.value).to eq(frozen_value)
+    end
+
+    it 'is a no-op when no formula has has_identite' do
+      # Build a dossier on a procedure with only a clock formula (no identite refs)
+      procedure_no_identite = create(:procedure, :published, :for_individual, types_de_champ_private: [
+        { type: :formule, libelle: 'Formule sans identite' },
+      ])
+      clock_only_tdc = procedure_no_identite.active_revision.types_de_champ.find(&:formule?)
+      clock_expr, _ = FormulaExpressionService.convert_to_stable_ids('AUJOURDHUI()', procedure_no_identite.active_revision)
+      clock_only_tdc.update!(formule_expression: clock_expr)
+
+      dossier_no_identite = create(:dossier, :with_individual, procedure: procedure_no_identite)
+      dossier_no_identite.compute_formulas_in_order
+
+      # Ensure has_identite is NOT set
+      expect(clock_only_tdc.reload.formule_deps&.[]('has_identite')).to be_falsey
+
+      expect(dossier_no_identite).not_to receive(:compute_formulas_in_order)
+      expect { dossier_no_identite.refresh_formulas_with_identite_dependents }.not_to raise_error
+    end
+  end
+
   describe 'after_commit hook triggers refresh on state timestamp change' do
     it 'refreshes when en_instruction_at changes' do
       travel_to Time.zone.local(2026, 4, 19, 10, 0, 0) do


### PR DESCRIPTION
## Summary

Étape G du chantier **formule typage + dépendances** ([design doc](docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md) + [ajustements](docs/superpowers/specs/2026-05-21-formule-typage-dependances-ajustements.md)).

Branche le recalcul des formules `has_identite` (qui référencent `{individual_*}` ou `{entreprise_*}`) sur les actions controller qui modifient l'identité du déclarant. Avant cette PR, un changement d'identité ne déclenchait aucun recalcul → formules dépendantes restaient sur l'ancienne valeur.

**PR stackée sur #446** (étape F). Quand #446 mergera dans devpf, GitHub repointera automatiquement la base.

### Décision Aj-3 — appels explicites, pas d'`after_commit`

Le design d'origine proposait un `after_commit` sur `Individual` / `Etablissement`. La revue a tranché pour des appels explicites dans les controllers — respect de la convention "cascade explicite" documentée dans `CLAUDE.md` (section "Cascade des formules").

### Sites instrumentés

| Fichier | Site | Quand |
|---|---|---|
| `dossier_formula_refresh_concern.rb` | nouvelle méthode `refresh_formulas_with_identite_dependents` | — |
| `users/dossiers_controller.rb` | `update_identite` après `@dossier.update!(...identity_updated_at...)` | Modification nom/prénom/etc. d'un individu |
| `users/dossiers_controller.rb` | `create_etablissement_and_redirect` après `@dossier.update!(...last_champ_updated_at...)` | Création/changement d'établissement (couvre les deux branches < 9 chars / >= 9 chars de `update_siret`) |

### Méthode

```ruby
def refresh_formulas_with_identite_dependents
  matching = revision.types_de_champ.filter do |tdc|
    tdc.formule? && tdc.formule_deps&.[]('has_identite')
  end
  return if matching.empty?

  compute_formulas_in_order(only: matching.map(&:stable_id).to_set)
end
```

### Vérification `APIEntrepriseService.create_etablissement`

3 callers identifiés :
1. `update_siret` (controller) → converge sur `create_etablissement_and_redirect` → couvert ✅
2. `create_etablissement_and_redirect` (controller) → couvert ✅
3. `Champs::SiretChamp#fetch_external_data` → cascade champ via `ChampExternalDataConcern#refresh_formulas_after` (existant) → couvert pour `has_identite` parce que le champ SIRET référencé déclenchera le recalcul de tout dépendant via le `champs` path

Aucun caller hors controller à instrumenter pour `has_identite`.

### Tests

- `spec/models/concerns/dossier_formula_refresh_concern_spec.rb` : 3 scénarios (recalcul `has_identite`, non-recalcul clock, no-op quand aucune formule identite)
- `spec/controllers/users/dossiers_controller_spec.rb` : scénario `update_identite` end-to-end vérifiant que la formule `CONCATENER("Bonjour ", {individual_last_name})` se recalcule après PATCH

### Scope hors PR

- Scénarios système Capybara S1-S4 (en fin de chantier — PR séparée)
- Couverture controller pour `create_etablissement_and_redirect` (gap mineur identifié en review — `APIEntrepriseService` nécessite stubbing lourd, le concern spec couvre l'essentiel)

## Test plan

- [x] 170 specs verts (concern + controller)
- [x] Pas d'`after_commit` ajouté sur `Individual` ni `Etablissement` (vérifié par grep)
- [x] Rubocop vert
- [x] Comportement vérifié end-to-end via spec controller (PATCH → formule recalculée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
