### PR TITLE
test(formule): scénarios système S1-S4 chaîne formule (Capybara)

### DIFF
--- a/spec/system/instructeurs/formula_state_transition_spec.rb
+++ b/spec/system/instructeurs/formula_state_transition_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# pf: S2 — Recalcul d'une formule lors de la transition d'état "Passer en instruction".
+# Vérifie que refresh_formulas_after (ou compute_initial_formulas) est déclenché
+# après la transition, de sorte que la formule JOURS_ENTRE({dossier_en_instruction_at},
+# AUJOURDHUI()) vaut 0 le jour même de la mise en instruction.
+describe 'Formula recompute on state transition to en_instruction', js: true do
+  let(:password) { SECURE_PASSWORD }
+  let!(:instructeur) { create(:instructeur, password: password) }
+  let!(:procedure) do
+    create(:procedure, :published, instructeurs: [instructeur], types_de_champ_public: [
+      { type: :formule, libelle: 'Jours en instruction' },
+    ])
+  end
+  let!(:dossier) { create(:dossier, :en_construction, :with_entreprise, procedure: procedure) }
+  let(:formula_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == 'Jours en instruction' } }
+
+  before do
+    formula_tdc.update!(formule_expression: 'JOURS_ENTRE({dossier_en_instruction_at}, AUJOURDHUI())')
+  end
+
+  scenario "la formule vaut 0 le jour de la mise en instruction" do
+    login_as instructeur.user, scope: :user
+    visit instructeur_procedure_path(procedure)
+
+    click_on dossier.user.email
+    click_on 'Passer en instruction'
+    expect(page).to have_text('Dossier passé en instruction.')
+
+    dossier.reload
+    expect(dossier.state).to eq(Dossier.states.fetch(:en_instruction))
+
+    # La formule doit afficher 0 (passée en instruction aujourd'hui)
+    # et non "—" (FORMULA_NOT_COMPUTED_MARKER)
+    formula_champ = dossier.project_champs_public.find { |c| c.libelle == 'Jours en instruction' }
+    expect(formula_champ.value).to eq('0')
+    expect(formula_champ.value).not_to eq('—')
+    expect(formula_champ.value).not_to be_nil
+  end
+end

--- a/spec/system/users/formula_cascade_spec.rb
+++ b/spec/system/users/formula_cascade_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# pf: S1 — Cascade entre formules (A → B → C).
+# Vérifie que modifier un champ source déclenche bien le recalcul transitif :
+# Montant HT → TTC → TVA. Ce scénario cible les bugs de câblage dans la chaîne
+# controller → refresh_formulas_after → compute_formulas_in_order → display,
+# pas les calculs arithmétiques eux-mêmes.
+describe 'Formula cascade between formulas', js: true do
+  let(:password) { SECURE_PASSWORD }
+  let!(:user) { create(:user, password: password) }
+
+  let!(:procedure) do
+    create(:procedure, :published, :for_individual, types_de_champ_public: [
+      { type: :integer_number, libelle: 'Montant HT' },
+      { type: :formule, libelle: 'TTC' },
+      { type: :formule, libelle: 'TVA' },
+    ])
+  end
+
+  let(:user_dossier) { user.dossiers.first }
+
+  let(:montant_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == 'Montant HT' } }
+  let(:ttc_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == 'TTC' } }
+  let(:tva_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == 'TVA' } }
+
+  before do
+    ttc_tdc.update!(formule_expression: "{tdc#{montant_tdc.stable_id}} * 1.2")
+    tva_tdc.update!(formule_expression: "{tdc#{ttc_tdc.stable_id}} - {tdc#{montant_tdc.stable_id}}")
+
+    log_in(user, procedure)
+    fill_individual
+  end
+
+  scenario 'le recalcul transitif A→B→C est déclenché par le controller après autosave' do
+    find('.dom-ready')
+
+    fill_in('Montant HT', with: '100')
+    wait_for_autosave
+
+    # pf: attendre que la cascade soit persistée en DB (recalcul asynchrone possible)
+    wait_until { champ_value_for('TTC').present? }
+    wait_until { champ_value_for('TVA').present? }
+
+    # TTC = 100 * 1.2 = 120 (peut être "120" ou "120,00" selon le formatage)
+    expect(page).to have_text('120')
+    # TVA = TTC - Montant = 120 - 100 = 20 (pas d'assertion page-level ici : "20" est
+    # une sous-chaîne de "120" et serait vacuoirement vraie ; la vérification DB ci-dessous suffit)
+
+    # Vérification DB pour confirmer que les valeurs sont bien persistées
+    ttc_value = champ_value_for('TTC')
+    tva_value = champ_value_for('TVA')
+    expect(Rational(ttc_value).to_f).to eq(120.0)
+    expect(Rational(tva_value).to_f).to eq(20.0)
+  end
+
+  private
+
+  def log_in(user, procedure)
+    login_as user, scope: :user
+
+    visit "/commencer/#{procedure.path}"
+    click_on 'Commencer la démarche'
+
+    expect(page).to have_content('Votre identité')
+    expect(page).to have_current_path(identite_dossier_path(user_dossier))
+  end
+
+  def fill_individual
+    fill_in('Prénom', with: 'Jean', visible: true)
+    fill_in('Nom', with: 'Test', visible: true)
+    within '#identite-form' do
+      click_on 'Continuer'
+    end
+    expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
+  end
+
+  def champ_value_for(libelle)
+    champ = user_dossier.reload.project_champs_public.find { |c| c.libelle == libelle }
+    champ&.reload&.value
+  end
+end

--- a/spec/system/users/formula_identity_spec.rb
+++ b/spec/system/users/formula_identity_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# pf: S3 — Recalcul après modification de l'identité individuelle.
+# Vérifie que refresh_formulas_after est bien déclenché par le controller
+# identité (étape G) quand l'usager modifie son prénom/nom.
+# Les colonnes sont individual_first_name / individual_last_name
+# (cf. FormulaColumnResolver lines 63-66), PAS individual_prenom/individual_nom.
+describe 'Formula recompute on identity change', js: true do
+  let(:password) { SECURE_PASSWORD }
+  let!(:user) { create(:user, password: password) }
+
+  let!(:procedure) do
+    create(:procedure, :published, :for_individual, types_de_champ_public: [
+      { type: :formule, libelle: 'Salutation' },
+    ])
+  end
+
+  let(:user_dossier) { user.dossiers.first }
+  let(:formula_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == 'Salutation' } }
+
+  before do
+    # pf: les colonnes d'identité individuelle sont référencées par leur nom
+    # de colonne symbolique, pas par stable_id (elles ne sont pas des TypeDeChamp).
+    formula_tdc.update!(
+      formule_expression: "CONCATENER(\"Bonjour \", {individual_first_name}, \" \", {individual_last_name})"
+    )
+    login_as user, scope: :user
+    visit "/commencer/#{procedure.path}"
+    click_on 'Commencer la démarche'
+
+    expect(page).to have_content('Votre identité')
+    expect(page).to have_current_path(identite_dossier_path(user_dossier))
+  end
+
+  scenario 'la formule se recalcule quand le nom change dans le formulaire identité' do
+    # Première saisie de l'identité
+    fill_in('Prénom', with: 'Jean', visible: true)
+    fill_in('Nom', with: 'Dupont', visible: true)
+    within '#identite-form' do
+      click_on 'Continuer'
+    end
+    expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
+
+    # La formule doit afficher "Bonjour Jean DUPONT" (le nom est normalisé en majuscules)
+    wait_until { champ_value_for('Salutation').present? }
+    expect(page).to have_text('Bonjour Jean', normalize_ws: true)
+    expect(page).to have_text('DUPONT')
+
+    # Retourner sur la page identité et modifier le nom
+    visit identite_dossier_path(user_dossier)
+    expect(page).to have_content('Votre identité')
+
+    fill_in('Prénom', with: 'Jean', visible: true)
+    fill_in('Nom', with: 'Martin', visible: true)
+    within '#identite-form' do
+      click_on 'Continuer'
+    end
+    expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
+
+    # La formule doit maintenant afficher "Bonjour Jean MARTIN" (nom en majuscules)
+    wait_until { champ_value_for('Salutation').include?('Martin') || champ_value_for('Salutation').include?('MARTIN') }
+    expect(page).to have_text('Bonjour Jean', normalize_ws: true)
+    expect(page).to have_text('MARTIN')
+  end
+
+  private
+
+  def champ_value_for(libelle)
+    champ = user_dossier.reload.project_champs_public.find { |c| c.libelle == libelle }
+    champ&.reload&.value
+  end
+end

--- a/spec/system/users/formula_type_aware_display_spec.rb
+++ b/spec/system/users/formula_type_aware_display_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# pf: S4 — Vérifier que la valeur d'un champ formule de type "string" s'affiche
+# en texte brut, sans balise <time>. Bug historique : le sniffer de dates
+# appliquait Date.parse sur toute valeur commençant par "\A\d{4}-\d{2}-\d{2}",
+# rendant "2026-CAP-19297/288" dans un <time>. La correction consiste à
+# n'utiliser format_as_date que quand formule_output_type == 'date'.
+describe 'Formula type-aware display', js: true do
+  let(:password) { SECURE_PASSWORD }
+  let!(:user) { create(:user, password: password) }
+
+  let!(:procedure) do
+    create(:procedure, :published, :for_individual, types_de_champ_public: [
+      { type: :date, libelle: "Date d'arrivée" },
+      { type: :text, libelle: 'Référence transport' },
+      { type: :formule, libelle: 'Identifiant' },
+    ])
+  end
+
+  let(:user_dossier) { user.dossiers.first }
+
+  let(:date_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == "Date d'arrivée" } }
+  let(:ref_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == 'Référence transport' } }
+  let(:formula_tdc) { procedure.active_revision.types_de_champ_public.find { |t| t.libelle == 'Identifiant' } }
+
+  before do
+    # pf: utiliser stable_id pour éviter la résolution de libelle qui nécessite
+    # un contexte de révision complet — cohérent avec formule_cascade_audit_spec.
+    formula_tdc.update!(
+      formule_expression: "CONCATENER(\"\", ANNEE({tdc#{date_tdc.stable_id}}), \"-\", {tdc#{ref_tdc.stable_id}})"
+    )
+    log_in(user, procedure)
+    fill_individual
+  end
+
+  scenario "la valeur de la formule string n'est pas enveloppée dans une balise <time>" do
+    find('.dom-ready')
+
+    fill_in("Date d'arrivée", with: '2026-06-08')
+    fill_in('Référence transport', with: 'CAP-19297/288')
+    wait_for_autosave
+
+    wait_until { champ_value_for('Identifiant').present? }
+
+    # La valeur calculée doit être visible comme texte brut
+    expect(page).to have_text('2026-CAP-19297/288')
+
+    # La valeur ne doit PAS être enveloppée dans un <time> (bug historique du sniffer)
+    within(:xpath, "//*[contains(text(), '2026-CAP-19297/288')]/ancestor::*[contains(@class, 'fr-text')][1]") do
+      expect(page).not_to have_selector('time')
+    end
+  end
+
+  private
+
+  def log_in(user, procedure)
+    login_as user, scope: :user
+
+    visit "/commencer/#{procedure.path}"
+    click_on 'Commencer la démarche'
+
+    expect(page).to have_content('Votre identité')
+    expect(page).to have_current_path(identite_dossier_path(user_dossier))
+  end
+
+  def fill_individual
+    fill_in('Prénom', with: 'Jean', visible: true)
+    fill_in('Nom', with: 'Test', visible: true)
+    within '#identite-form' do
+      click_on 'Continuer'
+    end
+    expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
+  end
+
+  def champ_value_for(libelle)
+    champ = user_dossier.reload.project_champs_public.find { |c| c.libelle == libelle }
+    champ&.reload&.value
+  end
+end


### PR DESCRIPTION
## Summary

Tests système (Capybara) du chantier **formule typage + dépendances** ([design doc](docs/superpowers/specs/2026-05-20-formule-typage-dependances-design.md)).

Quatre scénarios end-to-end qui exercent la chaîne complète `controller → callback → refresh_formulas → compute_formulas_in_order → affichage` dans un vrai navigateur (Playwright via Selenium). L'historique du champ formule a montré que les bugs se logent dans cette chaîne de déclenchement, pas dans les calculs. Mémoire projet : "viser 1-3 scénarios Capybara par chantier".

**PR stackée sur #447** (étape G). Quand #447 mergera dans devpf, GitHub repointera la base.

### Scénarios

| # | Fichier | Vérifie |
|---|---|---|
| **S1** | `spec/system/users/formula_cascade_spec.rb` | Cascade A→B→C : modifier "Montant HT" recalcule TTC puis TVA (transitive) |
| **S2** | `spec/system/instructeurs/formula_state_transition_spec.rb` | Transition d'état dossier déclenche le recalcul des formules `has_state` (formule = `JOURS_ENTRE({dossier_en_instruction_at}, AUJOURDHUI())` = 0 le jour de l'instruction) |
| **S3** | `spec/system/users/formula_identity_spec.rb` | Modification d'identité usager déclenche le recalcul des formules `has_identite` (étape G) |
| **S4** | `spec/system/users/formula_type_aware_display_spec.rb` | Non-régression du bug d'origine — `"2026-CAP-19297/288"` rendu en texte brut, pas dans une balise `<time>` (étape A) |

### Choix de design

- **S2 assertion DB-only** : le déclenchement passe par le vrai bouton "Passer en instruction" (UI), mais l'assertion vérifie la valeur en base — l'UI instructeur pour relire la formule ajoute du bruit. Le trigger reste exercé.
- **S3 noms upcased** : l'app appelle `sanitize_uppercase(:nom)` côté `Individual` — les assertions vérifient `"DUPONT"` / `"MARTIN"`, pas la casse saisie.
- **S4 xpath scoped** : l'assertion `not_to have_selector('time')` est cantonnée au container `fr-text` qui contient la valeur calculée, pas à la page entière (évite de matcher des `<time>` parasites du header/footer).

### Temps d'exécution

**~29 secondes** pour les 4 scénarios — acceptable.

## Test plan

- [x] 4/4 spécs verts
- [x] Rubocop vert
- [x] S4 vérifie explicitement l'absence de `<time>` (la signature du bug d'origine)
- [x] Variables `{individual_first_name}` / `{individual_last_name}` (pas `_prenom`/`_nom`) per `FormulaColumnResolver`
- [x] Helper `champ_value_for` nil-safe (correction code review)
- [x] Pas d'assertion `have_text('20')` vacuously true (correction code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
