### PR TITLE
fix(formule+ux): visibilité erreur validation, ARRONDI_INF/SUP, ENTIER, et préservation Integer en aval (B-1 à B-4)

### DIFF
--- a/app/components/autosave_notice_component/autosave_notice_component.en.yml
+++ b/app/components/autosave_notice_component/autosave_notice_component.en.yml
@@ -2,7 +2,7 @@
 en:
   form:
     saved: 'Form saved'
-    error: 'Form in error'
+    error: "Save error — check the field in error."
   attestation:
     saved: 'Attestation saved'
     error: 'Attestation in error'

--- a/app/components/autosave_notice_component/autosave_notice_component.fr.yml
+++ b/app/components/autosave_notice_component/autosave_notice_component.fr.yml
@@ -2,7 +2,7 @@
 fr:
   form:
     saved: 'Formulaire enregistré'
-    error: 'Formulaire en erreur'
+    error: "Erreur de sauvegarde — vérifiez le champ en erreur."
   attestation:
     saved: 'Attestation enregistrée'
     error: 'Attestation en erreur'

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -37,7 +37,9 @@ module Administrateurs
         reload_procedure_with_includes
         @morphed = champ_components_starting_at(@coordinate)
       else
-        # Afficher l'erreur inline sous le champ au lieu d'un flash
+        # Afficher l'erreur inline sous le champ ET un toast d'échec
+        # pour que l'admin voie clairement que la sauvegarde a échoué.
+        @has_errors = true
         errors = type_de_champ.errors.full_messages.join(', ')
         @morphed = [champ_component_from(@coordinate, focused: false, errors:)]
       end

--- a/app/services/formula_ai_prompt_service.rb
+++ b/app/services/formula_ai_prompt_service.rb
@@ -176,6 +176,9 @@ class FormulaAiPromptService
       - `MIN(a, b, ...)` / `MAX(a, b, ...)` → nombre
       - `ABS(n)` → nombre — valeur absolue
       - `ARRONDI(n, [décimales])` → nombre — arrondi à `décimales` chiffres (0 par défaut)
+      - `ARRONDI_INF(n)` → nombre — entier le plus grand ≤ n (floor). Ex : `ARRONDI_INF(3.7)` = 3, `ARRONDI_INF(-3.2)` = -4.
+      - `ARRONDI_SUP(n)` → nombre — entier le plus petit ≥ n (ceil). Ex : `ARRONDI_SUP(3.2)` = 4, `ARRONDI_SUP(-3.7)` = -3.
+      - `ENTIER(n)` → nombre — partie entière (tronque vers zéro). Ex : `ENTIER(3.7)` = 3, `ENTIER(-3.7)` = -3. Utile pour caster un résultat numérique en entier (évite "xxx.0" en concaténation).
 
       ### Logique
       - `SI(condition, valeur_si_vrai, valeur_si_faux)` — équivalent ternaire

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -257,6 +257,15 @@ class FormulaCalculationService
       match ? match[0].tr(',', '.').to_f : 0
     })
 
+    # pf: ENTIER tronque vers zéro (to_i Ruby) — différent de ARRONDI_INF (floor).
+    # ENTIER(-3.7) = -3 alors que ARRONDI_INF(-3.7) = -4.
+    # Utile pour caster un résultat numérique en entier afin d'éviter "xxx.0"
+    # en concaténation : CONCATENER("00", ENTIER({tdc750}), "000").
+    calculator.add_function(:ENTIER, :numeric, -> (n) {
+      next nil if n.nil?
+      n.to_f.to_i
+    })
+
     add_french_date_functions(calculator)
   end
 

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -483,7 +483,21 @@ class FormulaCalculationService
     when :integer
       value.present? ? value.to_i : 0
     when :decimal
-      value.present? ? value.to_f : 0
+      # pf: une formule de type 'number' qui retourne un entier (ex: ARRONDI(x, 0)
+      # → Integer 3 → stocké "3") doit rester Integer quand elle est référencée
+      # par une autre formule, sinon CONCATENER("00", {tdc_A}, "000") ressort
+      # "003.0000" parce qu'un Float 3.0 est injecté dans Dentaku.
+      # La value reçue peut être String ("3.7"), Float (4.0 après cast colonne)
+      # ou Integer — on normalise vers Integer quand la valeur est sans partie
+      # décimale, Float sinon.
+      return 0 if value.blank?
+      case value
+      when Integer then value
+      when Float, BigDecimal then value % 1 == 0 ? value.to_i : value.to_f
+      else
+        s = value.to_s
+        Integer(s, exception: false) || s.to_f
+      end
     when :boolean
       # pf: on passe des booléens natifs à Dentaku (pas 0/1) pour que le
       # typage soit préservé jusqu'à format_result. Une formule `{CaseACocher}`

--- a/app/views/administrateurs/types_de_champ/_insert.turbo_stream.haml
+++ b/app/views/administrateurs/types_de_champ/_insert.turbo_stream.haml
@@ -16,7 +16,13 @@
 
 = turbo_stream.replace 'summary', render(TypesDeChampEditor::HeaderSectionsSummaryComponent.new(procedure: @procedure, is_private: @coordinate&.private?))
 
-- unless flash.alert
+- if flash.alert
+  -# flash.alert path: pas de toast autosave (l'alerte est rendue ailleurs)
+- elsif @has_errors
+  = turbo_stream.show 'autosave-notice'
+  = turbo_stream.replace 'autosave-notice', render(AutosaveNoticeComponent.new(success: false, label_scope: :form))
+  -# pas de hide auto — l'utilisateur doit voir l'erreur jusqu'à action
+- else
   = turbo_stream.show 'autosave-notice'
   = turbo_stream.replace 'autosave-notice', render(AutosaveNoticeComponent.new(success: true, label_scope: :form))
   = turbo_stream.hide 'autosave-notice', delay: 30000

--- a/config/initializers/dentaku_french_aliases.rb
+++ b/config/initializers/dentaku_french_aliases.rb
@@ -25,16 +25,20 @@ require 'dentaku'
 #     (première occurrence seulement).
 # Restent en lambda custom dans FormulaCalculationService#add_french_functions.
 {
-  SI:         :if,
-  SOMME:      :sum,
-  MOYENNE:    :avg,
-  ABS:        :abs,
-  ARRONDI:    :round,
-  CONCATENER: :concat,
-  GAUCHE:     :left,
-  DROITE:     :right,
-  STXT:       :mid,
-  NBCAR:      :len,
+  SI:           :if,
+  SOMME:        :sum,
+  MOYENNE:      :avg,
+  ABS:          :abs,
+  ARRONDI:      :round,
+  # pf: floor / ceil — ARRONDI_INF(-3.2) = -4, ARRONDI_SUP(-3.7) = -3.
+  # Différent de ENTIER qui tronque vers zéro (ENTIER(-3.7) = -3).
+  ARRONDI_INF:  :rounddown,
+  ARRONDI_SUP:  :roundup,
+  CONCATENER:   :concat,
+  GAUCHE:       :left,
+  DROITE:       :right,
+  STXT:         :mid,
+  NBCAR:        :len,
 }.each do |fr_name, native_name|
   native_class = Dentaku::AST::Function.get(native_name)
   Dentaku::AST::Function.register_class(fr_name, native_class)

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -103,6 +103,38 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       end
     end
 
+    context 'when updating a formule TDC with an invalid expression' do
+      let(:procedure) do
+        create(:procedure,
+               types_de_champ_public: [
+                 { type: :formule, libelle: 'Ma formule', formule_expression: '1 + 1' },
+               ])
+      end
+
+      def formule_coordinate = procedure.draft_revision.revision_types_de_champ_public.first
+
+      it 'sets @has_errors so the view shows the failure toast' do
+        post :update, params: {
+          procedure_id: procedure.id,
+          stable_id: formule_coordinate.stable_id,
+          type_de_champ: { formule_expression: 'FONCTION_INEXISTANTE()' },
+        }, format: :turbo_stream
+        expect(assigns(:has_errors)).to be true
+        expect(assigns(:morphed)).to be_present
+        expect(flash.alert).to be_nil
+      end
+
+      it 'does NOT set @has_errors on successful update' do
+        post :update, params: {
+          procedure_id: procedure.id,
+          stable_id: formule_coordinate.stable_id,
+          type_de_champ: { formule_expression: '2 + 2' },
+        }, format: :turbo_stream
+        expect(assigns(:has_errors)).to be_falsey
+        expect(flash.alert).to be_nil
+      end
+    end
+
     context 'rejected if type changed and routing involved' do
       let(:params) do
         default_params.deep_merge(type_de_champ: { type_champ: 'text', stable_id: third_coordinate.stable_id })

--- a/spec/services/formula_ai_prompt_service_spec.rb
+++ b/spec/services/formula_ai_prompt_service_spec.rb
@@ -21,6 +21,12 @@ describe FormulaAiPromptService do
       expect(subject).to include('ANNEES_ENTRE')
     end
 
+    it 'documents the new rounding functions' do
+      expect(subject).to include('ARRONDI_INF')
+      expect(subject).to include('ARRONDI_SUP')
+      expect(subject).to include('ENTIER')
+    end
+
     it 'documents DUREE_SEMAINES' do
       expect(subject).to include('DUREE_SEMAINES')
     end

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -78,6 +78,67 @@ describe FormulaCalculationService do
       # and SOMME receives it as a single array argument, which flatten() handles
     end
 
+    context 'ARRONDI_INF, ARRONDI_SUP, ENTIER functions' do
+      let(:formule_champ) { Champs::FormuleChamp.new(dossier: dossier) }
+
+      def compute(expression)
+        allow(formule_champ).to receive(:type_de_champ).and_return(build(:type_de_champ_formule, formule_expression: expression))
+        service.compute_value(formule_champ)
+      end
+
+      # ARRONDI_INF (floor)
+      it 'ARRONDI_INF floors a positive non-integer' do
+        expect(compute('ARRONDI_INF(3.7)')).to eq('3')
+      end
+
+      it 'ARRONDI_INF floors a negative non-integer' do
+        expect(compute('ARRONDI_INF(-3.2)')).to eq('-4')
+      end
+
+      it 'ARRONDI_INF is a no-op on an exact integer' do
+        expect(compute('ARRONDI_INF(5)')).to eq('5')
+      end
+
+      # ARRONDI_SUP (ceil)
+      it 'ARRONDI_SUP ceils a positive non-integer' do
+        expect(compute('ARRONDI_SUP(3.2)')).to eq('4')
+      end
+
+      it 'ARRONDI_SUP ceils a negative non-integer' do
+        expect(compute('ARRONDI_SUP(-3.7)')).to eq('-3')
+      end
+
+      it 'ARRONDI_SUP is a no-op on an exact integer' do
+        expect(compute('ARRONDI_SUP(5)')).to eq('5')
+      end
+
+      # ENTIER (truncation toward zero)
+      it 'ENTIER truncates a positive non-integer toward zero' do
+        expect(compute('ENTIER(3.7)')).to eq('3')
+      end
+
+      it 'ENTIER truncates a negative non-integer toward zero' do
+        expect(compute('ENTIER(-3.7)')).to eq('-3')
+      end
+
+      it 'ENTIER is a no-op on an exact integer' do
+        expect(compute('ENTIER(5)')).to eq('5')
+      end
+
+      it 'ENTIER on zero returns zero' do
+        expect(compute('ENTIER(0)')).to eq('0')
+      end
+
+      # Cross-check: floor vs truncation differ for negatives
+      it 'ARRONDI_INF and ENTIER differ for negative non-integers' do
+        floor_result    = compute('ARRONDI_INF(-3.5)')
+        truncate_result = compute('ENTIER(-3.5)')
+        expect(floor_result).to    eq('-4')
+        expect(truncate_result).to eq('-3')
+        expect(floor_result).not_to eq(truncate_result)
+      end
+    end
+
     context 'ET/OU/NON functions with real procedure and revision' do
       let(:procedure) {
         create(:procedure, :published, types_de_champ_public: [

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -451,6 +451,52 @@ describe FormulaCalculationService do
       end
     end
 
+    # pf: non-régression — une formule qui retourne un entier (ex: ARRONDI(x, 0)
+    # ou un simple {champ_entier}) ne doit PAS introduire un "x.0" quand elle
+    # est référencée par une autre formule. format_value_for_dentaku case :decimal
+    # doit préserver le type Integer si la valeur stockée est sans décimale.
+    context 'when a formula references another numeric formula that returned an integer' do
+      let(:procedure) {
+        create(:procedure, :published, types_de_champ_public: [
+          { type: :decimal_number, libelle: 'X' },
+          { type: :formule, libelle: 'Rounded' }, # ARRONDI({X}, 0)
+          { type: :formule, libelle: 'Label' }, # CONCATENER("00", {Rounded}, "000")
+        ])
+      }
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure: procedure) }
+      let(:x_champ) { dossier.project_champs_public[0] }
+      let(:rounded_champ) { dossier.project_champs_public[1] }
+      let(:label_champ) { dossier.project_champs_public[2] }
+      let(:service) { described_class.new(dossier, locale: :fr) }
+
+      before do
+        expr_r, _ = FormulaExpressionService.convert_to_stable_ids('ARRONDI({X}, 0)', procedure.active_revision)
+        rounded_champ.type_de_champ.update(formule_expression: expr_r)
+        rounded_champ.type_de_champ.valid?
+        rounded_champ.type_de_champ.save!
+
+        expr_l, _ = FormulaExpressionService.convert_to_stable_ids('CONCATENER("00", {Rounded}, "000")', procedure.active_revision)
+        label_champ.type_de_champ.update(formule_expression: expr_l)
+      end
+
+      it 'does not introduce a ".0" artifact when concatenating a formula that returned an integer' do
+        x_champ.update(value: '3.7')
+        rounded_champ.update(value: service.compute_value(rounded_champ)) # "4"
+        expect(rounded_champ.reload.value).to eq('4')
+        expect(service.compute_value(label_champ)).to eq('004000')
+      end
+
+      it 'preserves the decimal when the upstream formula actually returns a decimal' do
+        x_champ.update(value: '3.74')
+        # une formule décimale réelle ne doit pas perdre ses décimales
+        decimal_expr, _ = FormulaExpressionService.convert_to_stable_ids('{X} * 2', procedure.active_revision)
+        rounded_champ.type_de_champ.update(formule_expression: decimal_expr)
+        rounded_champ.update(value: service.compute_value(rounded_champ)) # "7.48"
+        expect(rounded_champ.reload.value).to eq('7.48')
+        expect(service.compute_value(label_champ)).to eq('007.48000')
+      end
+    end
+
     # pf: non-régression — une formule qui référence juste un champ booléen
     # (checkbox, yes_no, ou formule booléenne) doit rendre "true"/"false",
     # pas "1"/"0". Le typage boolean doit se propager jusqu'à format_result.


### PR DESCRIPTION
## Summary

Quatre fixes UX/DSL trouvés en debug d'un dossier réel (712), notés dans [`2026-05-21-formule-typage-dependances-ajustements.md`](docs/superpowers/specs/2026-05-21-formule-typage-dependances-ajustements.md).

### B-1 — Erreur de validation rendue visible

Commit `62353c2e0f`. Quand la validation d'un `TypeDeChamp` échouait côté serveur (ex: expression formule invalide), l'admin voyait simultanément un encart rouge inline + un toast vert "Sauvegardé" — faux positif qui masquait cognitivement l'échec.

**Fix** : `@has_errors = true` dans la branche `else` de `update`, et `_insert.turbo_stream.haml` rend désormais un toast d'erreur (`AutosaveNoticeComponent` `success: false`, sans auto-hide) au lieu du toast vert.

### B-2 — `ARRONDI_INF` et `ARRONDI_SUP` au DSL

Commit `03b4e50ea7`. Ajout via alias Dentaku natifs (`:rounddown` / `:roundup`) — cohérent avec `ARRONDI` qui alias `:round`. `ARRONDI_INF(3.7) = 3`, `ARRONDI_INF(-3.2) = -4` (floor). `ARRONDI_SUP(3.2) = 4`, `ARRONDI_SUP(-3.7) = -3` (ceil).

### B-3 — `ENTIER(n)` au DSL

Même commit. Lambda custom `n.to_f.to_i` (truncation vers zéro, sémantique distincte de `ARRONDI_INF` pour les négatifs : `ENTIER(-3.7) = -3` vs `ARRONDI_INF(-3.7) = -4`). Utile pour caster un résultat de formule en entier en évitant les artefacts `.0` (le besoin direct du debug initial).

### B-4 — Éviter `.0` quand une formule entière est référencée

Commit `77fc601315`. **Bug latent indépendant trouvé en investiguant B-3.**

Quand une formule retourne un entier (`ARRONDI(x, 0) → 3`, stocké `"3"`) et qu'une formule aval la référence via `CONCATENER`, on ressortait `"003.0000"`. Cause : `format_value_for_dentaku` case `:decimal` faisait toujours `value.to_f`, transformant l'entier stocké en Float 3.0.

**Fix** : dispatch par classe de `value` — Integer reste Integer, Float/BigDecimal sans partie décimale → Integer, sinon Float. String parsée via `Integer(s, exception: false) || s.to_f`. Pas de regex, pas de `.to_s` inutile sur les cas Numeric.

## Test plan

- [x] 28 specs verts dans `types_de_champ_controller_spec.rb` (B-1)
- [x] 114 specs verts dans `formula_calculation_service_spec.rb` (B-2, B-3, B-4 + tous les pré-existants)
- [x] Spec dédié pour B-4 : formule chaînée avec entier → pas de `.0`
- [x] Rubocop vert sur tous les fichiers touchés

## Documentation IA mise à jour

Le prompt généré par `FormulaAiPromptService` documente désormais les trois nouvelles fonctions arithmétiques avec exemples (positifs et négatifs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)