### PR TITLE
feat(api/graphql): alléger la query par défaut en retirant `columns` du fragment racine

### DIFF
--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -512,9 +512,9 @@ class API::V2::StoredQuery
     stringValue
     updatedAt
     prefilled
-    columns {
-      ...ColumnFragment
-    }
+    # pf: `columns` retiré du fragment racine (redondant avec stringValue + sous-objets
+    # typés pour la majorité des types). Réintroduit ci-dessous uniquement sur les
+    # types où il porte une information non disponible ailleurs.
     ... on DateChamp {
       date
     }
@@ -549,6 +549,10 @@ class API::V2::StoredQuery
     ... on PieceJustificativeChamp {
       files {
         ...FileFragment
+      }
+      # pf: columns expose les champs OCR pour les PJ de type RIB (titulaire, IBAN, BIC, banque)
+      columns {
+        ...ColumnFragment
       }
     }
     ... on AddressChamp {
@@ -634,6 +638,14 @@ class API::V2::StoredQuery
     }
     ... on ExplicationChamp {
       __typename
+    }
+    # pf: TableColumn éclate value_json via referentiel_mapping_displayable
+    ... on ReferentielDePolynesieChamp {
+      columns {
+        name
+        value
+        type
+      }
     }
   }
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -160,24 +160,34 @@ describe API::V2::GraphqlController do
           ]
         end
         let(:dossier) { create(:dossier, :en_construction, :with_individual, :with_populated_champs, procedure:) }
-        let(:columns) { gql_data[:dossier][:champs].flat_map { _1[:columns] } }
+        let(:champs) { gql_data[:dossier][:champs] }
 
-        it {
+        # pf: la query par défaut n'expose `columns` que sur les types qui apportent
+        # une information non disponible ailleurs (PJ pour OCR RIB,
+        # ReferentielDePolynesieChamp pour l'éclatement référentiel). Les champs
+        # simples sont décrits via stringValue et leurs sous-objets typés
+        # (etablissement, address, commune, …).
+        it 'expose columns only on types that carry non-redundant data' do
           expect(gql_errors).to be_nil
           expect(gql_data[:dossier][:id]).to eq(dossier.to_typed_id)
-          expect(gql_data[:dossier][:champs].size).to eq(7)
-          expect(columns.size).to eq(13)
+          expect(champs.size).to eq(7)
 
-          expect(columns[0]).to include(label: "label text", value: 'text')
-          expect(columns[1]).to include(label: "label integer_number", value: "42")
-          expect(columns[2]).to include(label: "label decimal_number", value: 42.1)
-          expect(columns[3]).to include(label: "label checkbox", value: true)
-          expect(columns[4][:value].first).to include(__typename: "File", filename: "toto.txt", contentType: "text/plain")
-          expect(columns[5]).to include(label: "label multiple_drop_down_list", value: ["val1", "val2"])
+          text_champ, int_champ, dec_champ, cb_champ, pj_champ, mdd_champ, siret_champ = champs
 
-          expect(columns[6]).to include(label: "label entreprise – SIRET", value: '44011762001530')
-          expect(columns[7]).to include(label: "label entreprise – Entreprise raison sociale", value: 'GRTGAZ')
-        }
+          # types couverts par stringValue ou sous-objets typés : pas de columns
+          expect(text_champ).not_to have_key(:columns)
+          expect(int_champ).not_to have_key(:columns)
+          expect(dec_champ).not_to have_key(:columns)
+          expect(cb_champ).not_to have_key(:columns)
+          expect(mdd_champ).not_to have_key(:columns)
+          expect(siret_champ).not_to have_key(:columns)
+
+          # PJ conserve columns (utile pour les colonnes OCR des RIB)
+          expect(pj_champ[:columns].size).to eq(1)
+          expect(pj_champ[:columns].first[:value].first).to include(
+            __typename: "File", filename: "toto.txt", contentType: "text/plain"
+          )
+        end
       end
     end
 


### PR DESCRIPTION
## Contexte

La query par défaut `ds-query-v2` exposée par le playground GraphQL et utilisée comme modèle par les intégrations (n8n notamment) demandait `columns { ...ColumnFragment }` pour **tous** les types de champs dans `ChampFragment`.

Or pour la grande majorité des types, ce bloc fait doublon avec `stringValue` et les sous-objets typés déjà présents dans le fragment :

| Type | `columns` retourne | Déjà couvert par |
|---|---|---|
| Text / Number / Date / Boolean / Civilite / DropDown / MultiDropDown / Linked / Formule | 1 col label+value | `stringValue` (+ scalaires dédiés `date`, `integerNumber`, `values`, …) |
| Address / Commune / Epci / Departement / Region / Pays / CommuneDePolynesie / CodePostalDePolynesie | 1 col base (+ JSONPath éclatant l'adresse) | `address` / `commune` / `epci` / `pays` … et `departement` |
| Siret | base + `Etablissement::DISPLAYABLE_COLUMNS` (raison sociale, SIREN, …) | `etablissement { ...PersonneMoraleFragment }` |
| RNF | base + addressable + title | `rnf { id title address }` + `commune` + `departement` |

Conséquence côté n8n : la sortie devient **très volumineuse** et le mode debug souffre — chaque champ apporte une ligne `columns` inutile.

## Changement

`columns` est retiré du fragment racine `ChampFragment` et réintroduit uniquement sur les deux types qui apportent une information unique non disponible par ailleurs :

- **`PieceJustificativeChamp`** : éclatement OCR des RIB (titulaire, IBAN, BIC, nom banque) — non remplaçable.
- **`ReferentielDePolynesieChamp`** : éclatement `value_json` via le mapping `referentiel_mapping_displayable`, exposé en `TableColumn { name value type }`.

Le champ `columns` **reste exposé** dans le schéma GraphQL. Les clients qui en ont besoin pour un autre type (ex: SIRET) peuvent le redemander explicitement dans leur propre requête — c'est l'esprit GraphQL. Seule la requête servie comme modèle est allégée.

## Gain mesuré

Sur un dossier de 7 champs (text, integer, decimal, checkbox, PJ, multi, siret), la query par défaut renvoie désormais **1 entrée Column** au lieu de **13**. Effet multiplicatif sur les dossiers riches en répétitions.

## Pistes ultérieures évoquées

Trois chantiers liés ont été identifiés mais sortent du scope de cette PR (à traiter séparément) :

1. **Pousser l'éclatement multi-colonnes côté modèle** : implémenter `columns` dans `TypesDeChamp::ReferentielDePolynesieTypeDeChamp` (et upstream `ReferentielTypeDeChamp`) pour retourner plusieurs `Columns::JSONPathColumn` — bénéfice direct sur exports CSV, filtres, formules.
2. **Créer `Types::Champs::ReferentielChampType`** et y faire dériver `ReferentielDePolynesieChampType` (upstream n'a pas encore créé ce type GraphQL).
3. **Supprimer `TableColumn`** (redondant avec `Column` unifié) une fois les deux précédents faits — breaking change pour les consommateurs de `ReferentielDePolynesieChamp.columns`.

## Test plan

- [x] `bundle exec rspec spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb` (108 examples, 0 failures)
- [x] `bundle exec rspec spec/controllers/api/v2/graphql_controller_spec.rb spec/controllers/api/v2/graphql_controller_n+1_spec.rb` (60 examples, 0 failures)
- [ ] Vérifier dans le playground que la query par défaut renvoie bien `columns` uniquement sur PJ et ReferentielDePolynesie
- [ ] Côté n8n : copier la nouvelle query depuis le playground et constater la réduction de volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)