### PR TITLE
fix(i18n): restaurer header_section_level.gap_error hors de `models`

### DIFF
--- a/config/locales/models/type_de_champ/en.yml
+++ b/config/locales/models/type_de_champ/en.yml
@@ -71,11 +71,17 @@ en:
           rnf: RNF number
         not_filled: Not filled
     errors:
+      # pf: header_section_level.gap_error is resolved by an EXPLICIT I18n.t
+      # (cf. TypeDeChamp#check_coherent_header_level) → path WITHOUT `models`.
+      type_de_champ:
+        attributes:
+          header_section_level:
+            gap_error: 'An header section with %{level} is missing.'
+      # pf: formule_expression.* is added via errors.add → standard ActiveModel
+      # lookup through `models.<model>.attributes`.
       models:
         type_de_champ:
           attributes:
-            header_section_level:
-              gap_error: 'An header section with %{level} is missing.'
             formule_expression:
               invalid_field_reference: "Invalid field reference"
               invalid_syntax: "Invalid syntax: %{message}"

--- a/config/locales/models/type_de_champ/fr.yml
+++ b/config/locales/models/type_de_champ/fr.yml
@@ -82,11 +82,17 @@ fr:
           rnf: Numéro RNF
         not_filled: Non renseigné
     errors:
+      # pf: header_section_level.gap_error est résolu par un I18n.t EXPLICITE
+      # (cf. TypeDeChamp#check_coherent_header_level) → chemin SANS `models`.
+      type_de_champ:
+        attributes:
+          header_section_level:
+            gap_error: "devrait être précédé d'un titre de niveau %{level}"
+      # pf: formule_expression.* est ajouté via errors.add → lookup ActiveModel
+      # standard qui passe par `models.<model>.attributes`.
       models:
         type_de_champ:
           attributes:
-            header_section_level:
-              gap_error: "devrait être précédé d'un titre de niveau %{level}"
             formule_expression:
               invalid_field_reference: "Référence de champ invalide"
               invalid_syntax: "Syntaxe invalide: %{message}"


### PR DESCRIPTION
## Problème

CI rouge + `i18n-tasks missing` :
```
activerecord.errors.type_de_champ.attributes.header_section_level.gap_error
→ Translation missing  (app/models/type_de_champ.rb:601)
```

La PR i18n précédente avait déplacé **toutes** les clés d'erreur de `type_de_champ` sous `activerecord.errors.models.type_de_champ.attributes`. Or les deux familles n'utilisent pas le même chemin de lookup :

| Clé | Mécanisme | Chemin attendu |
|---|---|---|
| `formule_expression.*` | `errors.add(:formule_expression, …)` | `errors.**models**.type_de_champ.attributes.…` |
| `header_section_level.gap_error` | `I18n.t` **explicite** (`check_coherent_header_level`, type_de_champ.rb:601) | `errors.type_de_champ.attributes.…` (**sans** `models`) |

En déplaçant `gap_error` sous `models`, le `I18n.t` explicite ne la trouvait plus → "Translation missing".

## Correctif

On scinde : `header_section_level` reste hors `models`, `formule_expression.*` reste sous `models`. fr + en.

## Vérif
- `bundle exec i18n-tasks missing --locales fr` → ✓ aucune clé manquante
- `spec/components/procedures/errors_summary_spec.rb` + `spec/models/types_de_champ/formule_type_de_champ_spec.rb` → 64/64 vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)