### PR TITLE
fix(i18n): messages d'erreur formule + section (gap_error, invalid_syntax)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Continuous Integration
 on:
   push:
-    branches: ['main', 'devpf', 'masterpf', 'issue/*', 'feature/*', 'feature-ouidou/*', 'hotfix/*']
+    branches: ['main', 'devpf', 'masterpf', 'issue/*', 'feature/*', 'feature-ouidou/*', 'hotfix/*', 'fix/*']
   pull_request:
-    branches: ['main', 'devpf', 'masterpf', 'issue/*', 'feature/*', 'feature-ouidou/*']
+    branches: ['main', 'devpf', 'masterpf', 'issue/*', 'feature/*', 'feature-ouidou/*', 'hotfix/*', 'fix/*']
   merge_group:
     branches: ['main', 'devpf']
 

--- a/app/models/types_de_champ/formule_type_de_champ.rb
+++ b/app/models/types_de_champ/formule_type_de_champ.rb
@@ -177,7 +177,9 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
     # UnboundVariableError peu compréhensible pour l'utilisateur.
     hint = FormulaCalculationService.detect_equals_operator_hint(expression)
     if hint.present?
-      @type_de_champ.errors.add(:formule_expression, :invalid_syntax, message: hint)
+      # pf: interpolation via :detail (pas :message, clé réservée par
+      # errors.add → non conservée pour la ré-interpolation de full_messages).
+      @type_de_champ.errors.add(:formule_expression, :invalid_syntax, detail: hint)
       return
     end
 
@@ -204,7 +206,7 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
     @type_de_champ.formule_output_type = infer_output_type_from_reference(expression) || infer_output_type(ast_node)
   rescue Dentaku::ParseError, Dentaku::TokenizerError => e
     @type_de_champ.errors.add(:formule_expression, :invalid_syntax,
-                              message: FormulaCalculationService.translate_error(e))
+                              detail: FormulaCalculationService.translate_error(e))
   rescue StandardError
     # Autres erreurs Dentaku (UnboundVariable, etc.) — OK à ce stade,
     # les variables seront résolues au calcul.

--- a/config/locales/models/type_de_champ/en.yml
+++ b/config/locales/models/type_de_champ/en.yml
@@ -71,13 +71,19 @@ en:
           rnf: RNF number
         not_filled: Not filled
     errors:
+      # pf: header_section_level.gap_error is resolved by an EXPLICIT I18n.t
+      # (cf. TypeDeChamp#check_coherent_header_level) → path WITHOUT `models`.
+      type_de_champ:
+        attributes:
+          header_section_level:
+            gap_error: 'An header section with %{level} is missing.'
+      # pf: formule_expression.* is added via errors.add → standard ActiveModel
+      # lookup through `models.<model>.attributes`.
       models:
         type_de_champ:
           attributes:
-            header_section_level:
-              gap_error: 'An header section with %{level} is missing.'
             formule_expression:
               invalid_field_reference: "Invalid field reference"
-              invalid_syntax: "Invalid syntax: %{message}"
+              invalid_syntax: "Invalid syntax: %{detail}"
               circular_reference: "Circular reference detected — this formula references itself directly or through a chain of other formulas"
               forward_reference: "Reference to a field located after the formula — a formula can only reference fields that precede it"

--- a/config/locales/models/type_de_champ/fr.yml
+++ b/config/locales/models/type_de_champ/fr.yml
@@ -82,13 +82,19 @@ fr:
           rnf: Numéro RNF
         not_filled: Non renseigné
     errors:
+      # pf: header_section_level.gap_error est résolu par un I18n.t EXPLICITE
+      # (cf. TypeDeChamp#check_coherent_header_level) → chemin SANS `models`.
+      type_de_champ:
+        attributes:
+          header_section_level:
+            gap_error: "devrait être précédé d'un titre de niveau %{level}"
+      # pf: formule_expression.* est ajouté via errors.add → lookup ActiveModel
+      # standard qui passe par `models.<model>.attributes`.
       models:
         type_de_champ:
           attributes:
-            header_section_level:
-              gap_error: "devrait être précédé d'un titre de niveau %{level}"
             formule_expression:
               invalid_field_reference: "Référence de champ invalide"
-              invalid_syntax: "Syntaxe invalide: %{message}"
+              invalid_syntax: "Syntaxe invalide: %{detail}"
               circular_reference: "Référence circulaire détectée — cette formule s'auto-référence directement ou via une chaîne d'autres formules"
               forward_reference: "Référence à un champ situé après la formule — une formule ne peut référencer que des champs qui la précèdent"


### PR DESCRIPTION
> Remplace la #453 (branche `fix/*` renommée en `feature/*` ; #453 fermée automatiquement).

## Contexte

Une fois les clés d'erreur de `formule_expression` correctement résolues (PR i18n précédente), deux bugs i18n latents ont été exposés.

## Corrections

### 1. `header_section_level.gap_error` — restauré hors de `models`
Résolu par un `I18n.t` **explicite** (`TypeDeChamp#check_coherent_header_level`, type_de_champ.rb:601) → chemin `activerecord.errors.type_de_champ.attributes…` **sans** `models`. La PR précédente l'avait déplacé sous `models` avec `formule_expression` → "Translation missing".

### 2. `invalid_syntax` — interpolation `%{detail}` au lieu de `%{message}`
`message:` est une clé **réservée** de `errors.add` : consommée comme override du message, elle n'est pas conservée pour la ré-interpolation de `full_messages` → `I18n::MissingInterpolationArgument :message`. On passe `detail:` (clé non réservée) côté `errors.add` + `%{detail}` côté YAML.

| Clé | Mécanisme | Chemin |
|---|---|---|
| `formule_expression.*` | `errors.add` | `errors.**models**.type_de_champ.attributes` |
| `header_section_level.gap_error` | `I18n.t` explicite | `errors.type_de_champ.attributes` (sans models) |

## Bonus CI
`ci.yml` : ajout de `fix/*` aux triggers push + pull_request (ne déclenchaient aucune CI), et alignement de `hotfix/*` sur pull_request.

## Vérif
- `bundle exec i18n-tasks missing --locales fr` → ✓
- `errors_summary_spec`, `formule_type_de_champ_spec` (58), `types_de_champ_controller_spec` (invalid expression) → verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)