### PR TITLE
feat(formule): agrégation sur blocs répétables ({Bloc/Sous-champ})

### DIFF
--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -46,7 +46,20 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
     # Optimize: create hash map to avoid N+1 queries
     @types_de_champ_by_stable_id ||= revision.types_de_champ.index_by(&:stable_id)
 
-    base = coordinate.available_columns_for_formula.map do |col|
+    own_parent_sid = coordinate.parent_type_de_champ&.stable_id
+
+    base = coordinate.available_columns_for_formula.filter_map do |col|
+      # pf: pour une formule HORS d'un bloc, on retire les sous-champs-ligne des
+      # répétitions (label "Bloc – Sous-champ", réf {tdc<sub_id>}) : ils ne sont
+      # référençables qu'au sein de leur propre ligne. Hors bloc, c'est la forme
+      # agrégat "Bloc/Sous-champ" (cf. repetition_aggregate_columns) qui doit être
+      # proposée. On garde les siblings quand la formule est DANS le même bloc.
+      if col.is_a?(Columns::ChampColumn) && col.stable_id.present?
+        col_tdc = @types_de_champ_by_stable_id[col.stable_id]
+        parent = col_tdc && revision.parent_of(col_tdc)
+        next if parent&.repetition? && parent.stable_id != own_parent_sid
+      end
+
       {
         id: encode_column_id(col),
         label: col.label,

--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -46,7 +46,7 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
     # Optimize: create hash map to avoid N+1 queries
     @types_de_champ_by_stable_id ||= revision.types_de_champ.index_by(&:stable_id)
 
-    coordinate.available_columns_for_formula.map do |col|
+    base = coordinate.available_columns_for_formula.map do |col|
       {
         id: encode_column_id(col),
         label: col.label,
@@ -54,6 +54,39 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
         category: col.table,
         paths: extract_sub_paths(col),
       }.compact
+    end
+
+    # pf: entrées bloc-agrégat — un bloc répétable placé AVANT la formule peut
+    # être agrégé : NB({Bloc}) ou SOMME({Bloc/Sous-champ}). On expose le bloc
+    # comme colonne (label = libellé du bloc → {tdc<bloc>}) avec un `path` par
+    # sous-champ (label composite "Bloc/Sous-champ" → {tdc<bloc>/sub_<id>}). Le
+    # JS convertToColumnIds mappe ces labels sans modification (cf.
+    # formula_editor_controller.ts).
+    base + repetition_aggregate_columns
+  end
+
+  # pf: blocs répétables agrégables (placés avant la formule) + leurs sous-champs.
+  def repetition_aggregate_columns
+    reference_position = coordinate.parent&.position || coordinate.position
+    own_parent_sid = coordinate.parent_type_de_champ&.stable_id
+
+    revision.types_de_champ.filter_map do |tdc|
+      next unless tdc.repetition?
+      next if tdc.stable_id == own_parent_sid
+
+      bloc_coordinate = revision.coordinate_for(tdc)
+      next if bloc_coordinate.nil? || bloc_coordinate.position >= reference_position
+
+      sub_paths = revision.children_of(tdc).filter(&:fillable?).map do |sub|
+        { path: "sub_#{sub.stable_id}", label: "#{tdc.libelle}/#{sub.libelle}" }
+      end
+
+      {
+        id: "tdc#{tdc.stable_id}",
+        label: tdc.libelle,
+        type: 'repetition',
+        paths: sub_paths,
+      }
     end
   end
 

--- a/app/javascript/controllers/formula_autocomplete_controller.ts
+++ b/app/javascript/controllers/formula_autocomplete_controller.ts
@@ -195,15 +195,41 @@ export class FormulaAutocompleteController extends ApplicationController {
    * Filter columns based on query using fuzzy matching
    */
   private filterColumns(query: string): ColumnReference[] {
+    const columns = this.flattenedColumns();
+
     if (query === '') {
       // Return all columns if no query
-      return this.availableColumnsValue.slice(0, 10);
+      return columns.slice(0, 10);
     }
 
-    return matchSorter(this.availableColumnsValue, query, {
+    return matchSorter(columns, query, {
       keys: ['label'],
       threshold: matchSorter.rankings.CONTAINS
     }).slice(0, 10);
+  }
+
+  /**
+   * pf: Aplatit les colonnes et leurs sous-chemins (paths) en une liste plate
+   * de suggestions. Chaque colonne contribue elle-même (ex: "Facture" → NB/COUNT,
+   * "Numéro DN" → la valeur) PLUS une entrée par sous-chemin avec son label
+   * composite (ex: "Facture/Prix HT" → SOMME, "Numéro DN – Date de naissance").
+   * L'insertion utilise le label ; formula_editor#convertToColumnIds le remappe
+   * ensuite vers l'identifiant interne ({tdc<bloc>/sub_<id>}, {tdc<dn>/date_de_naissance}…).
+   */
+  private flattenedColumns(): ColumnReference[] {
+    const result: ColumnReference[] = [];
+    for (const column of this.availableColumnsValue) {
+      result.push(column);
+      for (const path of column.paths ?? []) {
+        result.push({
+          id: `${column.id}/${path.path}`,
+          label: path.label,
+          type: column.type,
+          category: column.category
+        });
+      }
+    }
+    return result;
   }
 
   /**

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -353,9 +353,12 @@ class Champ < ApplicationRecord
       (tdc.formule_deps&.[]('champs') || []).each { |dep_sid| deps_graph[dep_sid].add(tdc.stable_id) }
     end
 
-    # BFS topologique depuis self.stable_id
+    # pf: BFS topologique depuis self.stable_id ET, si ce champ est dans un bloc
+    # répétable, depuis le stable_id du bloc parent. Une formule-agrégat dépend
+    # du stable_id du BLOC ({tdc<bloc>/sub_<id>} → dep = bloc), donc modifier un
+    # sous-champ d'une ligne doit déclencher les formules qui dépendent du bloc.
     visited = Set.new
-    queue = deps_graph[stable_id].to_a
+    queue = (dependency_seed_stable_ids).flat_map { |sid| deps_graph[sid].to_a }
     result = []
     while (sid = queue.shift)
       next if visited.include?(sid)
@@ -391,10 +394,22 @@ class Champ < ApplicationRecord
 
   private
 
+  # pf: stable_ids "sources" qui doivent déclencher une cascade de formules
+  # quand ce champ change : lui-même, plus le bloc répétable parent le cas
+  # échéant (granularité bloc des formules-agrégat — cf. dependent_formula_stable_ids).
+  def dependency_seed_stable_ids
+    seeds = [stable_id]
+    parent_bloc_sid = dossier.revision.parent_of(type_de_champ)&.stable_id
+    seeds << parent_bloc_sid if parent_bloc_sid
+    seeds
+  end
+
   def dependent_formula_champs_from(all_champs)
+    source_sids = dependency_seed_stable_ids
     all_champs.filter do |formula_champ|
       next false if formula_champ.stable_id.nil?
-      next false unless formula_champ.formule? && (formula_champ.type_de_champ.formule_deps&.[]('champs') || []).include?(stable_id)
+      deps = formula_champ.type_de_champ.formule_deps&.[]('champs') || []
+      next false unless formula_champ.formule? && (deps & source_sids).any?
 
       if row_id.present?
         formula_champ.row_id == row_id || formula_champ.row_id.nil?

--- a/app/models/types_de_champ/formule_type_de_champ.rb
+++ b/app/models/types_de_champ/formule_type_de_champ.rb
@@ -335,8 +335,39 @@ class TypesDeChamp::FormuleTypeDeChamp < TypesDeChamp::TypeDeChampBase
       .filter_map { |col| col.stable_id if col.is_a?(Columns::ChampColumn) }
       .to_set
 
+    # pf: Les TDC repetition n'apparaissent pas dans available_columns_for_formula
+    # (repetition.columns retourne les columns des sous-TDC, pas du bloc). Pour
+    # les formules-agrégat ({tdc<bloc>}, {tdc<bloc>/sub_<id>}), on autorise les
+    # blocs placés AVANT la formule.
+    allowed_stable_ids.merge(allowed_repetition_bloc_stable_ids(coordinate))
+
     extract_dependent_stable_ids(@type_de_champ.formule_expression)
       .any? { |dep_id| !allowed_stable_ids.include?(dep_id) }
+  end
+
+  # pf: Renvoie les stable_id des TDC repetition placés avant la formule,
+  # éligibles comme cible d'agrégation. Le bloc parent de la formule (si
+  # formule dans un bloc) est exclu pour éviter une auto-référence.
+  def allowed_repetition_bloc_stable_ids(coordinate)
+    revision = coordinate.revision
+    formula_position = coordinate.position
+    own_parent_position = coordinate.parent&.position
+    own_parent_sid = coordinate.parent_type_de_champ&.stable_id
+
+    revision.types_de_champ.filter_map do |tdc|
+      next unless tdc.repetition?
+      next if tdc.stable_id == own_parent_sid
+
+      bloc_coordinate = revision.coordinate_for(tdc)
+      next if bloc_coordinate.nil?
+
+      # Si formule top-level : bloc accepté s'il précède la formule.
+      # Si formule dans un bloc : bloc accepté s'il précède le bloc parent.
+      reference_position = own_parent_position || formula_position
+      next unless bloc_coordinate.position < reference_position
+
+      tdc.stable_id
+    end
   end
 
   # pf: Construit le Hash formule_deps depuis l'expression brute (regex).

--- a/app/services/formula_ai_prompt_service.rb
+++ b/app/services/formula_ai_prompt_service.rb
@@ -50,7 +50,7 @@ class FormulaAiPromptService
       inaccessible_variables_section,
       functions_section,
       operators_and_syntax_section,
-      unsupported_section,
+      repetition_aggregate_section,
       response_format_section,
       self_check_section,
       user_request_placeholder,
@@ -173,11 +173,14 @@ class FormulaAiPromptService
       ### Arithmétique
       - `SOMME(a, b, ...)` → nombre — somme de tous les arguments
       - `MOYENNE(a, b, ...)` → nombre — moyenne arithmétique
+      - `MEDIANE(a, b, ...)` → nombre — valeur médiane
       - `MIN(a, b, ...)` / `MAX(a, b, ...)` → nombre
+      - `NB(...)` (ou `COMPTE(...)`) → nombre — nombre d’éléments (utile sur un bloc répétable, cf. plus bas)
       - `ABS(n)` → nombre — valeur absolue
+      - `RACINE(n)` → nombre — racine carrée
       - `ARRONDI(n, [décimales])` → nombre — arrondi à `décimales` chiffres (0 par défaut)
-      - `ARRONDI_INF(n)` → nombre — entier le plus grand ≤ n (floor). Ex : `ARRONDI_INF(3.7)` = 3, `ARRONDI_INF(-3.2)` = -4.
-      - `ARRONDI_SUP(n)` → nombre — entier le plus petit ≥ n (ceil). Ex : `ARRONDI_SUP(3.2)` = 4, `ARRONDI_SUP(-3.7)` = -3.
+      - `ARRONDI_INF(n)` (ou `PLANCHER(n)`) → nombre — entier le plus grand ≤ n (floor). Ex : `ARRONDI_INF(3.7)` = 3, `ARRONDI_INF(-3.2)` = -4.
+      - `ARRONDI_SUP(n)` (ou `PLAFOND(n)`) → nombre — entier le plus petit ≥ n (ceil). Ex : `ARRONDI_SUP(3.2)` = 4, `ARRONDI_SUP(-3.7)` = -3.
       - `ENTIER(n)` → nombre — partie entière (tronque vers zéro). Ex : `ENTIER(3.7)` = 3, `ENTIER(-3.7)` = -3. Utile pour caster un résultat numérique en entier (évite "xxx.0" en concaténation).
 
       ### Logique
@@ -197,6 +200,7 @@ class FormulaAiPromptService
       - `MAJUSCULE(texte)` / `MINUSCULE(texte)` → texte
       - `SUPPRESPACE(texte)` → texte — supprime les espaces en début/fin et réduit les espaces multiples
       - `VALEUR(texte)` → nombre — convertit un texte en nombre (gère la virgule française, retourne 0 si non convertible)
+      - `JOINDRE(liste, séparateur)` → texte — concatène les valeurs d’un sous-champ de bloc répétable avec un séparateur (équivalent texte de SOMME, cf. plus bas). Ex : `JOINDRE({Partenaires/Raison sociale}, ", ")`.
 
       ### Date
       Les champs de type date sont manipulés comme des objets Date natifs. L’arithmétique `+` `-` et les comparaisons `<` `>` `==` fonctionnent directement entre deux dates, ou entre une date et une durée.
@@ -242,29 +246,38 @@ class FormulaAiPromptService
     TXT
   end
 
-  def unsupported_section
+  def repetition_aggregate_section
     <<~TXT
-      ## Fonctionnalités NON DISPONIBLES actuellement
+      ## Agrégation sur blocs répétables
 
-      ### Blocs répétables (tableaux)
       Un « bloc répétable » est un groupe de champs que l’usager peut dupliquer
-      (par exemple : liste d’enfants, liste de revenus, liste de dépenses).
-      On peut se les représenter comme un **tableau** :
-      - une **colonne** par champ du bloc (ex: « Prénom de l’enfant », « Âge de l’enfant »),
-      - une **ligne** par répétition remplie par l’usager.
+      (liste d’enfants, lignes de facture, ...). On peut se le représenter comme
+      un **tableau** : une **colonne** par sous-champ, une **ligne** par répétition.
 
-      ⚠️ **Aucune fonction ne peut actuellement manipuler ces tableaux.** Il est impossible de :
-      - compter le nombre de lignes (pas de NBLIGNES, NB.SI, ...),
-      - sommer une colonne sur toutes les lignes (pas de SOMME.SI, SOMMEPROD, ...),
-      - filtrer les lignes selon une condition,
-      - accéder à une ligne précise par son index.
+      Une formule placée **EN DEHORS** du bloc peut agréger ses lignes :
+      - `NB({Nom du bloc})` → nombre de lignes. Ex : `NB({Lignes de facture})`.
+      - `SOMME({Nom du bloc/Sous-champ})` → somme d’un sous-champ sur toutes les lignes.
+        Ex : `SOMME({Lignes de facture/Prix HT})`.
+      - de même `MOYENNE`, `MIN`, `MAX`, `MEDIANE` sur `{Bloc/Sous-champ}`.
+      - `JOINDRE({Bloc/Sous-champ}, ", ")` → concatène un sous-champ texte de toutes
+        les lignes. Ex : `JOINDRE({Partenaires/Raison sociale}, ", ")`.
+      - combinaisons : `SOMME({Factures/Montant}) - SOMME({Paiements/Montant})`.
 
-      Les champs situés DANS un bloc répétable ne sont référençables depuis une
-      formule située elle aussi DANS le même bloc (la formule est alors
-      évaluée ligne par ligne). **Aucun agrégat global n’est possible.**
+      ⚠️ **Placement obligatoire** : la formule-agrégat doit être située APRÈS le bloc
+      dans le formulaire (une formule ne référence que des champs qui la précèdent).
 
-      **Si le besoin implique un agrégat sur un bloc répétable** (total, moyenne,
-      nombre de lignes, ...), réponds `IMPOSSIBLE`.
+      ### Transformation par ligne (pas de SI/calcul inline sur les lignes)
+      Il n’y a pas de filtre conditionnel d’agrégat (pas de SOMME.SI, ni de calcul
+      par ligne dans l’agrégat lui-même). Pour cela, ajouter une **formule-ligne
+      intermédiaire DANS le bloc** puis l’agréger de l’extérieur. Ex : pour le total
+      TTC, créer dans le bloc « Montant TTC » = `{Prix HT} * 1.2`, puis hors bloc
+      `SOMME({Lignes de facture/Montant TTC})`.
+
+      ## Fonctionnalités NON DISPONIBLES actuellement (blocs)
+      - filtrer les lignes selon une condition au sein de l’agrégat (SOMME.SI…),
+      - accéder à une ligne précise par son index,
+      - agréger entre deux blocs différents dans une même expression de bas niveau
+        (utiliser deux agrégats combinés par un opérateur, comme l’exemple ci-dessus).
     TXT
   end
 
@@ -298,7 +311,7 @@ class FormulaAiPromptService
         réorganiser le formulaire, faire saisir autrement…).
 
       Exemples de réponses IMPOSSIBLE valides :
-      - `IMPOSSIBLE: aucune agrégation sur un bloc répétable n’est disponible.` Suggestion : faire saisir un total directement par l’usager dans un champ nombre, ou ajouter un champ formule dans le bloc qui sera ensuite exploité hors bloc une fois la Phase 2 du moteur déployée.
+      - `IMPOSSIBLE: l’agrégat doit filtrer les lignes selon une condition (SOMME.SI).` Suggestion : ajouter une formule-ligne dans le bloc qui calcule la valeur conditionnelle par ligne (ex : `SI({Type} == "A", {Montant}, 0)`), puis l’agréger hors bloc avec `SOMME({Bloc/cette formule-ligne})`.
       - `IMPOSSIBLE: le champ « Nom du conjoint » existe mais n’est pas accessible depuis cette formule.` Suggestion : placer « Nom du conjoint » avant le champ formule dans le formulaire.
     TXT
   end

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -266,6 +266,24 @@ class FormulaCalculationService
       n.to_f.to_i
     })
 
+    # pf: MEDIANE — pas de fonction native median en Dentaku 3.5.4. Accepte
+    # une liste d'arguments OU un array (binding {bloc/sous-champ}). nil/blank
+    # ignorés. Médiane = valeur centrale (impair) ou moyenne des deux centrales.
+    calculator.add_function(:MEDIANE, :numeric, -> (*args) {
+      nums = args.flatten.compact.map(&:to_f).sort
+      next nil if nums.empty?
+      mid = nums.size / 2
+      nums.size.odd? ? nums[mid] : (nums[mid - 1] + nums[mid]) / 2.0
+    })
+
+    # pf: JOINDRE(array, séparateur) — concatène les valeurs d'un array en une
+    # chaîne (équivalent texte de SOMME). Pensé pour agréger un sous-champ texte
+    # d'un bloc : JOINDRE({Partenaires/Raison sociale}, ", "). nil/vide ignorés.
+    # Pas de join natif en Dentaku → lambda custom (cf. CHERCHE/SUBSTITUE).
+    calculator.add_function(:JOINDRE, :string, -> (arr, separator = ', ') {
+      Array(arr).flatten.compact.map(&:to_s).reject(&:empty?).join(separator.to_s)
+    })
+
     add_french_date_functions(calculator)
   end
 
@@ -442,7 +460,7 @@ class FormulaCalculationService
   # que si l'usager les a saisis — un row vide n'aurait sinon aucun champ).
   def repetition_live_row_ids(bloc_tdc)
     all_champs
-      .select { |c| c.stable_id == bloc_tdc.stable_id && c.row_id.present? && !c.discarded? }
+      .filter { |c| c.stable_id == bloc_tdc.stable_id && c.row_id.present? && !c.discarded? }
       .map(&:row_id)
       .uniq
   end
@@ -465,7 +483,7 @@ class FormulaCalculationService
     # RepetitionChamp, pas sur les sous-champs.)
     live_row_ids = repetition_live_row_ids(bloc_tdc).to_set
     rows_champs = all_champs
-      .select { |c| c.row_id.present? && c.stable_id == sub_tdc.stable_id && live_row_ids.include?(c.row_id) }
+      .filter { |c| c.row_id.present? && c.stable_id == sub_tdc.stable_id && live_row_ids.include?(c.row_id) }
       .sort_by(&:row_id)
 
     rows_champs.filter_map { |champ| coerce_repetition_champ_value(champ, sub_tdc) }
@@ -484,9 +502,9 @@ class FormulaCalculationService
     when 'decimal_number', 'number'
       champ.value.to_f
     when 'date'
-      Date.parse(champ.value) rescue nil # rubocop:disable Style/RescueModifier
+      Date.parse(champ.value) rescue nil
     when 'datetime'
-      DateTime.parse(champ.value) rescue nil # rubocop:disable Style/RescueModifier
+      DateTime.parse(champ.value) rescue nil
     when 'yes_no'
       champ.value == 'true'
     when 'checkbox'

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -414,12 +414,72 @@ class FormulaCalculationService
       # New column-based resolution
       column, path = @resolver.resolve_with_path(reference)
 
+      # pf: Blocs répétables — agrégation hors bloc (chantier formule-agrégat).
+      # Dentaku 3.5.4 supporte SUM/COUNT/MAX/MIN/AVG sur arrays bindings.
+      # Le binding {bloc} reçoit la liste des row_ids (suffit pour COUNT) ;
+      # {bloc/sub} reçoit un array de scalaires type-aware.
+      case column
+      when FormulaColumnResolver::RepetitionRef
+        next register_variable(extract_repetition_row_ids(column.bloc_tdc))
+      when FormulaColumnResolver::RepetitionSubChampRef
+        next register_variable(extract_repetition_values(column.bloc_tdc, column.sub_tdc))
+      end
+
       if column.nil?
         raise InvalidFieldReferenceError, reference
       end
 
       value = extract_column_value(column, path)
       register_variable(format_value_for_dentaku(value, column.type))
+    end
+  end
+
+  # pf: Renvoie l'array des row_ids du bloc — utilisé pour COUNT/NB({bloc}).
+  # On lit les RepetitionChamps (un par row, créé dès repetition_add_row),
+  # plus fiable que de passer par les sous-champs (qui n'existent que si
+  # l'usager les a saisis — un row vide n'aurait sinon aucun champ).
+  def extract_repetition_row_ids(bloc_tdc)
+    all_champs
+      .select { |c| c.stable_id == bloc_tdc.stable_id && c.row_id.present? }
+      .map(&:row_id)
+      .uniq
+  end
+
+  # pf: Renvoie l'array des valeurs (type-aware) d'un sous-champ de toutes
+  # les lignes du bloc. Les valeurs nil sont filtrées pour éviter qu'une
+  # ligne incomplète n'écrase une agrégation (SUM, MAX) — comportement
+  # cohérent avec les agrégateurs SQL et avec format_result qui rend nil
+  # quand le calcul échoue (ex: MAX sur array vide).
+  def extract_repetition_values(_bloc_tdc, sub_tdc)
+    rows_champs = all_champs
+      .select { |c| c.row_id.present? && c.stable_id == sub_tdc.stable_id }
+      .sort_by(&:row_id)
+
+    rows_champs.filter_map { |champ| coerce_repetition_champ_value(champ, sub_tdc) }
+  end
+
+  # pf: Conversion typée d'un champ sous-TDC vers le type Ruby attendu par
+  # Dentaku. Distincte de format_value_for_dentaku (qui prend un type Column,
+  # pas type_champ). Retourne nil pour les champs vides afin d'être filtrés
+  # par filter_map dans extract_repetition_values.
+  def coerce_repetition_champ_value(champ, tdc)
+    return nil if champ.value.blank?
+
+    case tdc.type_champ
+    when 'integer_number'
+      champ.value.to_i
+    when 'decimal_number', 'number'
+      champ.value.to_f
+    when 'date'
+      Date.parse(champ.value) rescue nil # rubocop:disable Style/RescueModifier
+    when 'datetime'
+      DateTime.parse(champ.value) rescue nil # rubocop:disable Style/RescueModifier
+    when 'yes_no'
+      champ.value == 'true'
+    when 'checkbox'
+      champ.value == 'on'
+    else
+      champ.value.to_s
     end
   end
 

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -481,12 +481,40 @@ class FormulaCalculationService
     # RepetitionChamp de la ligne l'est) — le filtre par live_row_ids suffit à
     # exclure les lignes supprimées. (discarded? n'est d'ailleurs défini que sur
     # RepetitionChamp, pas sur les sous-champs.)
-    live_row_ids = repetition_live_row_ids(bloc_tdc).to_set
+    live_row_ids = repetition_live_row_ids(bloc_tdc)
+
+    # pf: cas d'un sous-champ FORMULE-LIGNE. Son Champ n'est pas forcément
+    # persisté (formule_champs_for_tdc fait `return [] if tdc.child?` — la
+    # cascade ne crée pas les champs formule enfants ; en preview ils n'existent
+    # que matérialisés dans project_champs). On NE peut PAS lire project_champs
+    # ici (récursion : ça recalculerait la formule-agrégat courante). On calcule
+    # donc la formule-ligne à la volée pour chaque ligne : elle ne référence que
+    # ses siblings de même ligne, qui SONT persistés dans all_champs.
+    if sub_tdc.formule?
+      return live_row_ids.sort.filter_map do |row_id|
+        value = compute_line_formula_value(sub_tdc, row_id)
+        next nil if value.blank?
+        coerce_formule_output(value, sub_tdc.formule_output_type)
+      end
+    end
+
+    live_row_ids_set = live_row_ids.to_set
     rows_champs = all_champs
-      .filter { |c| c.row_id.present? && c.stable_id == sub_tdc.stable_id && live_row_ids.include?(c.row_id) }
+      .filter { |c| c.row_id.present? && c.stable_id == sub_tdc.stable_id && live_row_ids_set.include?(c.row_id) }
       .sort_by(&:row_id)
 
     rows_champs.filter_map { |champ| coerce_repetition_champ_value(champ, sub_tdc) }
+  end
+
+  # pf: Calcule la valeur d'une formule-ligne pour une row donnée, sans dépendre
+  # d'un Champ persisté. Réutilise un Champ existant si présent, sinon en build
+  # un in-memory. Un service dédié (scopé sur le row via compute_value →
+  # @row_id) résout les siblings de la ligne. value_overrides partagé pour la
+  # transitivité amont.
+  def compute_line_formula_value(sub_tdc, row_id)
+    champ = all_champs.find { |c| c.stable_id == sub_tdc.stable_id && c.row_id == row_id }
+    champ ||= sub_tdc.build_champ(dossier: @dossier, row_id:, stream: @dossier.stream)
+    self.class.new(@dossier, locale: @locale, value_overrides: @value_overrides).compute_value(champ)
   end
 
   # pf: Conversion typée d'un champ sous-TDC vers le type Ruby attendu par

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -509,8 +509,28 @@ class FormulaCalculationService
       champ.value == 'true'
     when 'checkbox'
       champ.value == 'on'
+    when 'formule'
+      # pf: un sous-champ formule stocke un résultat en string ; on coerce selon
+      # son type de sortie inféré pour que SOMME/MOYENNE/MAX… sur une colonne
+      # formule fonctionnent (sinon "1000" reste une string → SOMME = 0).
+      coerce_formule_output(champ.value, tdc.formule_output_type)
     else
       champ.value.to_s
+    end
+  end
+
+  def coerce_formule_output(value, output_type)
+    case output_type
+    when 'number'
+      value.match?(/\A-?\d+\z/) ? value.to_i : value.to_f
+    when 'boolean'
+      value == Champs::BooleanChamp::TRUE_VALUE
+    when 'date'
+      Date.parse(value) rescue nil
+    when 'datetime'
+      DateTime.parse(value) rescue nil
+    else # 'string' ou nil
+      value.to_s
     end
   end
 

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -434,25 +434,38 @@ class FormulaCalculationService
     end
   end
 
-  # pf: Renvoie l'array des row_ids du bloc — utilisé pour COUNT/NB({bloc}).
-  # On lit les RepetitionChamps (un par row, créé dès repetition_add_row),
-  # plus fiable que de passer par les sous-champs (qui n'existent que si
-  # l'usager les a saisis — un row vide n'aurait sinon aucun champ).
-  def extract_repetition_row_ids(bloc_tdc)
+  # pf: Renvoie l'array des row_ids VIVANTS du bloc — utilisé pour COUNT/NB({bloc}).
+  # On lit les RepetitionChamps (un par row, créé dès repetition_add_row) en
+  # excluant les lignes supprimées : repetition_remove_row fait discard! sur le
+  # RepetitionChamp de la ligne (cf. repetition_row_ids qui filtre aussi
+  # !discarded?). Plus fiable que de passer par les sous-champs (qui n'existent
+  # que si l'usager les a saisis — un row vide n'aurait sinon aucun champ).
+  def repetition_live_row_ids(bloc_tdc)
     all_champs
-      .select { |c| c.stable_id == bloc_tdc.stable_id && c.row_id.present? }
+      .select { |c| c.stable_id == bloc_tdc.stable_id && c.row_id.present? && !c.discarded? }
       .map(&:row_id)
       .uniq
   end
 
-  # pf: Renvoie l'array des valeurs (type-aware) d'un sous-champ de toutes
-  # les lignes du bloc. Les valeurs nil sont filtrées pour éviter qu'une
-  # ligne incomplète n'écrase une agrégation (SUM, MAX) — comportement
-  # cohérent avec les agrégateurs SQL et avec format_result qui rend nil
-  # quand le calcul échoue (ex: MAX sur array vide).
-  def extract_repetition_values(_bloc_tdc, sub_tdc)
+  def extract_repetition_row_ids(bloc_tdc)
+    repetition_live_row_ids(bloc_tdc)
+  end
+
+  # pf: Renvoie l'array des valeurs (type-aware) d'un sous-champ pour toutes les
+  # lignes VIVANTES du bloc. On filtre par les row_ids vivants : quand une ligne
+  # est supprimée, c'est son RepetitionChamp qui est discardé, pas le sous-champ
+  # lui-même — il faut donc l'exclure via la liste des lignes vivantes.
+  # Les valeurs nil sont filtrées pour éviter qu'une ligne incomplète n'écrase
+  # une agrégation (SUM, MAX) — cohérent avec les agrégateurs SQL et avec
+  # format_result qui rend nil sur array vide (ex: MAX).
+  def extract_repetition_values(bloc_tdc, sub_tdc)
+    # pf: les sous-champs ne sont jamais discardés individuellement (seul le
+    # RepetitionChamp de la ligne l'est) — le filtre par live_row_ids suffit à
+    # exclure les lignes supprimées. (discarded? n'est d'ailleurs défini que sur
+    # RepetitionChamp, pas sur les sous-champs.)
+    live_row_ids = repetition_live_row_ids(bloc_tdc).to_set
     rows_champs = all_champs
-      .select { |c| c.row_id.present? && c.stable_id == sub_tdc.stable_id }
+      .select { |c| c.row_id.present? && c.stable_id == sub_tdc.stable_id && live_row_ids.include?(c.row_id) }
       .sort_by(&:row_id)
 
     rows_champs.filter_map { |champ| coerce_repetition_champ_value(champ, sub_tdc) }

--- a/app/services/formula_calculation_service.rb
+++ b/app/services/formula_calculation_service.rb
@@ -508,13 +508,20 @@ class FormulaCalculationService
 
   # pf: Calcule la valeur d'une formule-ligne pour une row donnée, sans dépendre
   # d'un Champ persisté. Réutilise un Champ existant si présent, sinon en build
-  # un in-memory. Un service dédié (scopé sur le row via compute_value →
-  # @row_id) résout les siblings de la ligne. value_overrides partagé pour la
-  # transitivité amont.
+  # un in-memory. Un service dédié (scopé sur le row via compute_value → @row_id)
+  # résout les siblings de la ligne depuis all_champs (valeurs par ligne).
+  #
+  # pf: on NE propage PAS @value_overrides : il est keyé par stable_id (row-aveugle),
+  # donc l'override d'un sous-champ d'UNE ligne (ex: Prix HT row1 = 150 fraîchement
+  # modifié) fuirait sur TOUTES les lignes et corromprait l'agrégat (row2 calculerait
+  # avec 150 au lieu de sa propre valeur). Les valeurs par ligne sont lues fraîches
+  # depuis all_champs (sources persistées). La limitation per-row de value_overrides
+  # est ce que la refonte « passe accumulante » (keyée par (stable_id, row_id))
+  # résoudra proprement — cf. docs/superpowers/specs/2026-05-28-formule-passe-accumulante-design.md.
   def compute_line_formula_value(sub_tdc, row_id)
     champ = all_champs.find { |c| c.stable_id == sub_tdc.stable_id && c.row_id == row_id }
     champ ||= sub_tdc.build_champ(dossier: @dossier, row_id:, stream: @dossier.stream)
-    self.class.new(@dossier, locale: @locale, value_overrides: @value_overrides).compute_value(champ)
+    self.class.new(@dossier, locale: @locale).compute_value(champ)
   end
 
   # pf: Conversion typée d'un champ sous-TDC vers le type Ruby attendu par

--- a/app/services/formula_column_resolver.rb
+++ b/app/services/formula_column_resolver.rb
@@ -3,6 +3,23 @@
 # Service to resolve formula column references to actual Column objects
 # Converts semantic identifiers like "tdc456" or "dossier_number" to Column instances
 class FormulaColumnResolver
+  # pf: Référence à un bloc répétable, pour les formules-agrégat hors bloc
+  # (ex: SOMME({Lignes de facture/Prix HT}), NB({Lignes de facture})).
+  # Le consommateur (FormulaCalculationService) dispatche sur le type
+  # retourné par #resolve pour construire le binding Dentaku adapté.
+  RepetitionRef = Struct.new(:bloc_tdc, keyword_init: true) do
+    def repetition_ref? = true
+    def sub_champ_ref? = false
+  end
+
+  # pf: Référence à un sous-champ d'un bloc répétable, accédé via la
+  # syntaxe {tdc<bloc>/sub_<sub_id>} après résolution du libellé. Encodage
+  # par stable_id (option A') pour résister au renommage du sous-champ.
+  RepetitionSubChampRef = Struct.new(:bloc_tdc, :sub_tdc, keyword_init: true) do
+    def repetition_ref? = false
+    def sub_champ_ref? = true
+  end
+
   def initialize(revision, row_id: nil)
     @revision = revision
     @procedure = revision.procedure
@@ -17,10 +34,12 @@ class FormulaColumnResolver
 
   # Resolves {tdc456/date_de_naissance} → [Column, path]
   #
-  # pf: Les colonnes à sous-chemin (JSONPathColumn, LinkedDropDownColumn) sont
-  # indexées sous leur clé COMPLÈTE "tdc<N>/<path>" par encode_column_id. On
-  # consulte donc d'abord la clé complète : la colonne trouvée porte déjà sa
-  # propre logique d'extraction (jsonpath / path), on renvoie path=nil.
+  # pf: Les références composites "tdc<N>/<...>" sont indexées sous leur clé
+  # COMPLÈTE par build_columns_index : JSONPathColumn / LinkedDropDownColumn
+  # (sous-chemins type DN/date_de_naissance, commune/ile, SIRET/raison_sociale)
+  # ET les RepetitionSubChampRef des blocs répétables (tdc<bloc>/sub_<id>). On
+  # consulte donc d'abord la clé complète : l'objet trouvé porte déjà sa propre
+  # logique d'extraction, on renvoie path=nil.
   # Avant ce correctif, resolve_with_path splittait systématiquement et ne
   # résolvait que le préfixe "tdc<N>" → la ChampColumn de base, jamais la
   # JSONPathColumn — donc {Numéro DN/date_de_naissance}, {SIRET/raison_sociale}
@@ -55,7 +74,40 @@ class FormulaColumnResolver
       end
     end
 
+    # pf: Blocs répétables — entrées dédiées aux formules-agrégat hors bloc.
+    # Cohabite avec l'indexation scalaire des sous-TDC (utilisée par les
+    # formules-ligne dans le bloc, via leur stable_id à eux).
+    build_repetition_index(index)
+
     index
+  end
+
+  def build_repetition_index(index)
+    # pf: Une passe sur revision_types_de_champ pour grouper les sous-TDC
+    # par stable_id du bloc parent. Évite d'appeler children_of une fois
+    # par bloc — qui re-scanne lui-même tous les revision_types_de_champ
+    # (O(n) par appel, soit O(B × n) globalement).
+    rtdcs = @revision.revision_types_de_champ
+    rtdc_by_id = rtdcs.index_by(&:id)
+
+    children_by_parent_sid = Hash.new { |h, k| h[k] = [] }
+    rtdcs.each do |rtdc|
+      next if rtdc.parent_id.nil?
+      parent_rtdc = rtdc_by_id[rtdc.parent_id]
+      next if parent_rtdc.nil?
+      children_by_parent_sid[parent_rtdc.stable_id] << rtdc.type_de_champ
+    end
+
+    rtdcs.each do |rtdc|
+      tdc = rtdc.type_de_champ
+      next unless tdc.repetition?
+
+      index["tdc#{tdc.stable_id}"] = RepetitionRef.new(bloc_tdc: tdc)
+      children_by_parent_sid[tdc.stable_id].each do |sub_tdc|
+        key = "tdc#{tdc.stable_id}/sub_#{sub_tdc.stable_id}"
+        index[key] = RepetitionSubChampRef.new(bloc_tdc: tdc, sub_tdc: sub_tdc)
+      end
+    end
   end
 
   def build_system_columns_index(index)

--- a/app/services/formula_expression_service.rb
+++ b/app/services/formula_expression_service.rb
@@ -36,9 +36,15 @@ class FormulaExpressionService
           tdc = find_type_de_champ_by_stable_id(stable_id, revision)
 
           if tdc && path
-            # Sub-property: find the label for the path
-            path_label = find_path_label(tdc, path)
-            path_label ? "{#{path_label}}" : match
+            # pf: agrégat bloc répétable {tdc<bloc>/sub_<sub_id>} → {Bloc/Sous-champ}
+            if tdc.repetition? && (m = path.match(/\Asub_(\d+)\z/))
+              sub_tdc = find_type_de_champ_by_stable_id(m[1].to_i, revision)
+              sub_tdc ? "{#{tdc.libelle}/#{sub_tdc.libelle}}" : match
+            else
+              # Sub-property: find the label for the path
+              path_label = find_path_label(tdc, path)
+              path_label ? "{#{path_label}}" : match
+            end
           elsif tdc
             "{#{tdc.libelle}}"
           else

--- a/app/validators/types_de_champ/formula_validator.rb
+++ b/app/validators/types_de_champ/formula_validator.rb
@@ -60,12 +60,24 @@ class TypesDeChamp::FormulaValidator < ActiveModel::EachValidator
     # Extract all references {tdc456}, {dossier_number}, {tdc456/commune}
     referenced_ids = tdc.formule_expression.scan(/\{([^}]+)\}/).map(&:first)
 
+    # pf: stable_ids des blocs répétables agrégables (placés avant la formule).
+    allowed_bloc_sids = allowed_repetition_bloc_stable_ids(coordinate, revision)
+
     # Validate each reference
     referenced_ids.each do |ref|
       column, _ = resolver.resolve_with_path(ref)
 
       if column.nil?
         add_error(procedure, collection, tdc, "Colonne inconnue : #{ref}")
+        next
+      end
+
+      # pf: référence à un bloc répétable (agrégat) — {tdc<bloc>} ou
+      # {tdc<bloc>/sub_<id>}. On vérifie que le bloc précède la formule.
+      if column.is_a?(FormulaColumnResolver::RepetitionRef) || column.is_a?(FormulaColumnResolver::RepetitionSubChampRef)
+        unless allowed_bloc_sids.include?(column.bloc_tdc.stable_id)
+          add_error(procedure, collection, tdc, "ne peut référencer le bloc « #{column.bloc_tdc.libelle} » car une formule ne peut utiliser que les champs qui la précèdent")
+        end
         next
       end
 
@@ -92,6 +104,25 @@ class TypesDeChamp::FormulaValidator < ActiveModel::EachValidator
       end
       # System columns (dossier_*, individual_*, etc.) are always accessible
     end
+  end
+
+  # pf: blocs répétables (stable_ids) référençables en agrégat par une formule :
+  # ceux placés AVANT la formule (ou avant le bloc parent si la formule est
+  # elle-même dans un bloc), hors bloc parent. Aligné sur
+  # FormuleTypeDeChamp#allowed_repetition_bloc_stable_ids.
+  def allowed_repetition_bloc_stable_ids(coordinate, revision)
+    reference_position = coordinate.parent&.position || coordinate.position
+    own_parent_sid = coordinate.parent_type_de_champ&.stable_id
+
+    revision.types_de_champ.filter_map do |tdc|
+      next unless tdc.repetition?
+      next if tdc.stable_id == own_parent_sid
+
+      bloc_coordinate = revision.coordinate_for(tdc)
+      next if bloc_coordinate.nil? || bloc_coordinate.position >= reference_position
+
+      tdc.stable_id
+    end.to_set
   end
 
   # Old validation for backward compatibility (format {Label} or {123})

--- a/config/initializers/dentaku_french_aliases.rb
+++ b/config/initializers/dentaku_french_aliases.rb
@@ -39,6 +39,16 @@ require 'dentaku'
   DROITE:       :right,
   STXT:         :mid,
   NBCAR:        :len,
+  # pf: étape H — agrégation / maths. count et sqrt sont natifs Dentaku 3.5.4.
+  # NB / COMPTE comptent les éléments (utile sur un bloc : NB({Lignes})).
+  NB:           :count,
+  COMPTE:       :count,
+  RACINE:       :sqrt,
+  # pf: PLANCHER / PLAFOND = floor / ceil. Les natifs floor/ceil sont ABSENTS
+  # en 3.5.4 ; on réutilise rounddown / roundup (déjà employés par
+  # ARRONDI_INF / ARRONDI_SUP) — synonymes "math" pour la découvrabilité.
+  PLANCHER:     :rounddown,
+  PLAFOND:      :roundup,
 }.each do |fr_name, native_name|
   native_class = Dentaku::AST::Function.get(native_name)
   Dentaku::AST::Function.register_class(fr_name, native_class)

--- a/docs/superpowers/specs/2026-05-28-formule-passe-accumulante-design.md
+++ b/docs/superpowers/specs/2026-05-28-formule-passe-accumulante-design.md
@@ -1,0 +1,116 @@
+# Design doc — Refonte du calcul des formules : passe unique accumulante
+
+_Date : 2026-05-28 | Auteur : architecture review (clautier + Claude)_
+
+Spec d'intention pour une refonte ultérieure. Pas de chantier ouvert — capture
+le raisonnement validé pour remplacer le workaround « recalcul à la volée » des
+formules-ligne en répétition (cf. `app/services/formula_calculation_service.rb`
+→ `compute_line_formula_value`).
+
+---
+
+## 1. Problème actuel
+
+Le calcul des formules s'appuie aujourd'hui sur **trois mécanismes disjoints**,
+ce qui crée des angles morts :
+
+1. **`all_champs`** (`FormulaCalculationService`) = lecture directe de
+   `@dossier.champs` (persistés, filtrés par stream). Rapide, mais **ne contient
+   pas** les champs jamais persistés — notamment les **formules-ligne dans un
+   bloc** (`formule_champs_for_tdc` fait `return [] if tdc.child?`).
+2. **`value_overrides`** (`compute_formulas_in_order`) = accumulateur de valeurs
+   fraîches pour la transitivité A→B→C. **Keyé par `stable_id` seul** → incapable
+   de tenir une valeur **par ligne** (un sous-champ de bloc a un stable_id mais N
+   lignes). C'est la limite qui casse l'agrégat de formules-ligne.
+3. **Le garde anti-récursion** de `project_champ`
+   (`Thread.current[:dossier_champs_formule_recomputing]`) = recalcul en mémoire
+   à l'affichage draft, mais qui **bloque** toute relecture imbriquée → une
+   formule-agrégat ne peut pas lire une formule-ligne via `project_champs`.
+
+Conséquence : `SOMME({Bloc/Sous-formule})` ne trouvait aucune valeur. Workaround
+actuel : recalculer la formule-ligne à la volée pour chaque ligne (correct mais
+inélégant — cf. [[project_formule_ligne_repetition_materialization]]).
+
+---
+
+## 2. Cible : un seul accumulateur ordonné, keyé par ligne
+
+Une **passe unique** qui calcule les champs dans l'ordre et **stocke chaque
+résultat au fur et à mesure** dans un accumulateur que toute formule lit.
+
+### Structure
+- Accumulateur keyé par **`public_id` = (stable_id, row_id)** (et non `stable_id`
+  seul). C'est la clé de voûte : permet de tenir une valeur **par ligne**.
+- Remplace simultanément les 3 mécanismes : `all_champs` (lecture), `value_overrides`
+  (transitivité), et le garde de `project_champ` (plus nécessaire).
+
+### Ordre de la passe
+L'invariant qui rend la passe correcte et **sans récursion** existe déjà :
+`forward_reference?` garantit qu'une dépendance **précède toujours** son
+consommateur (pas de référence « vers l'avant », pas de cycle). Donc une passe
+en **ordre de position** suffit : au moment de calculer X, tout ce dont X dépend
+est déjà dans l'accumulateur.
+
+1. **Public, dans l'ordre des positions**, blocs **dépliés inline** : pour chaque
+   bloc → sous-champs sources puis formules-ligne **par ligne**, puis les
+   agrégats positionnés après le bloc.
+2. **Puis privé**, même logique.
+
+### Lectures (tout devient un lookup dans l'accumulateur)
+- **Formule-ligne** : lit ses siblings `(sibling_sid, même row_id)`.
+- **Agrégat de bloc** : lit toutes les entrées `(sub_sid, *)` du bloc.
+- **Formule racine** : lit `(sid, nil)`.
+- **Formule privée** : lit n'importe quelle entrée publique déjà calculée.
+
+---
+
+## 3. Le cas privé → public (et blocs)
+
+`forward_reference?` autorise une **annotation privée à référencer TOUT le
+public** (pas seulement ce qui précède). Traduction dans la passe : **tout le
+public doit être calculé avant la première formule privée** — naturellement
+satisfait par « public en entier, puis privé ».
+
+Au moment où une formule privée calcule, sont déjà dans l'accumulateur :
+- les formules publiques racine ✓
+- les **agrégats de blocs publics** (`SOMME({BlocPublic/...})`) ✓
+- les **formules-ligne publiques** (présentes par `(stable_id, row_id)`) ✓
+
+La dimension « ligne » de l'accumulateur est ce qui rend le cas bloc traitable —
+c'est précisément ce qui manque à `value_overrides` aujourd'hui.
+
+---
+
+## 4. Le point dur
+
+Le seul morceau non trivial : **l'ordre de dépliage des blocs** quand les
+dépendances croisent les frontières de lignes (formule-ligne → agrégat →
+formule racine → annotation privée → …). Comme `forward_reference` interdit déjà
+cycles et références avant, un **tri topologique par `(position, row_id)`** reste
+linéaire et déterministe.
+
+---
+
+## 5. Point de départ d'implémentation
+
+1. Remplacer `value_overrides` (keyé `stable_id`) par un accumulateur keyé
+   `public_id` dans `compute_formulas_in_order`.
+2. Faire lire `FormulaCalculationService` dans cet accumulateur **en priorité**
+   (avant `all_champs`).
+3. Déplier les lignes de bloc dans la passe (sous-champs + formules-ligne par
+   ligne) et **persister** les formules-ligne au passage (lève la limitation
+   `return [] if tdc.child?` de `formule_champs_for_tdc`).
+4. Retirer le workaround `compute_line_formula_value` et le garde
+   `dossier_champs_formule_recomputing` une fois la passe en place.
+5. Spec de non-régression : `spec/models/champs/formule_cascade_audit_spec.rb`
+   (agrégat de formule-ligne) + un cas **annotation privée agrégeant un bloc
+   public**.
+
+---
+
+## 6. Out of scope (ici)
+
+- L'implémentation elle-même (chantier séparé).
+- La perf fine de la passe (mais viser O(N champs), pas O(N²)).
+- Le bug de debug `Rails.log.info` (typo `Rails.logger`) dans
+  `DossierChampsConcern#project_champs_public_all` — à corriger indépendamment.

--- a/spec/components/types_de_champ_editor/champ_component_spec.rb
+++ b/spec/components/types_de_champ_editor/champ_component_spec.rb
@@ -137,6 +137,45 @@ describe TypesDeChampEditor::ChampComponent, type: :component do
     end
   end
 
+  # pf: la liste de colonnes alimente l'autocomplete de l'éditeur formule.
+  # Pour l'agrégat sur bloc répétable, on expose le bloc + des sous-chemins
+  # composites "Bloc/Sous-champ" (slash), et on RETIRE les sous-champs-ligne
+  # "Bloc – Sous-champ" (tiret) hors du bloc (inutiles, source de confusion).
+  describe '#available_columns_for_formula avec bloc répétable' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        {
+          type: :repetition, libelle: 'Facture', children: [
+            { type: :integer_number, libelle: 'Prix HT' },
+          ],
+        },
+        { type: :formule, libelle: 'Total' },
+      ])
+    end
+    let(:formule_tdc) { procedure.draft_revision.types_de_champ.find { _1.libelle == 'Total' } }
+    let(:coordinate) { procedure.draft_revision.coordinate_for(formule_tdc) }
+    let(:component) { described_class.new(coordinate:, upper_coordinates: []) }
+    let(:columns) { component.available_columns_for_formula }
+
+    it 'expose le bloc comme colonne agrégable' do
+      bloc = columns.find { _1[:label] == 'Facture' }
+      expect(bloc).to be_present
+      expect(bloc[:id]).to match(/\Atdc\d+\z/)
+    end
+
+    it 'expose le sous-champ en label composite "Facture/Prix HT" (slash)' do
+      bloc = columns.find { _1[:label] == 'Facture' }
+      sub = bloc[:paths].find { _1[:label] == 'Facture/Prix HT' }
+      expect(sub).to be_present
+      expect(sub[:path]).to match(/\Asub_\d+\z/)
+    end
+
+    it 'ne propose PAS la référence-ligne "Facture – Prix HT" (tiret) hors du bloc' do
+      labels = columns.map { _1[:label] }
+      expect(labels).not_to include(a_string_matching(/Facture – Prix HT|Facture - Prix HT/))
+    end
+  end
+
   describe 'ACCEPTED_TYPES' do
     it 'contains expected conversions' do
       expect(described_class::ACCEPTED_TYPES).to include(

--- a/spec/lib/dentaku_array_functions_spec.rb
+++ b/spec/lib/dentaku_array_functions_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# pf: Spec sentinelle — Dentaku 3.5.4 supporte SUM/COUNT/MAX/MIN/AVG sur
+# des arrays passés en binding (non documenté officiellement). Le chantier
+# « formules-agrégat sur blocs répétables » repose sur ce comportement.
+#
+# Si Dentaku change ce comportement à une upgrade future, cette spec rouge
+# avant que la résolution des formules-agrégat ne casse en prod.
+
+require 'dentaku'
+
+describe 'Dentaku — fonctions d\'agrégation sur arrays bindings' do
+  let(:calculator) { Dentaku::Calculator.new }
+
+  describe 'SUM' do
+    it 'somme les éléments d\'un array' do
+      expect(calculator.evaluate!('SUM(arr)', arr: [1, 2, 3])).to eq(6)
+    end
+
+    it 'retourne 0 sur un array vide' do
+      expect(calculator.evaluate!('SUM(arr)', arr: [])).to eq(0)
+    end
+
+    it 'supporte les decimals' do
+      expect(calculator.evaluate!('SUM(arr)', arr: [1.5, 2.5, 3.0])).to eq(7.0)
+    end
+  end
+
+  describe 'COUNT' do
+    it 'retourne la taille d\'un array' do
+      expect(calculator.evaluate!('COUNT(arr)', arr: [1, 2, 3])).to eq(3)
+    end
+
+    it 'retourne 0 sur un array vide' do
+      expect(calculator.evaluate!('COUNT(arr)', arr: [])).to eq(0)
+    end
+  end
+
+  describe 'MAX' do
+    it 'retourne le maximum d\'un array' do
+      expect(calculator.evaluate!('MAX(arr)', arr: [10, 30, 20])).to eq(30)
+    end
+
+    it 'retourne nil sur un array vide' do
+      expect(calculator.evaluate!('MAX(arr)', arr: [])).to be_nil
+    end
+  end
+
+  describe 'MIN' do
+    it 'retourne le minimum d\'un array' do
+      expect(calculator.evaluate!('MIN(arr)', arr: [10, 30, 20])).to eq(10)
+    end
+  end
+
+  describe 'AVG' do
+    it 'retourne la moyenne d\'un array' do
+      expect(calculator.evaluate!('AVG(arr)', arr: [10, 20, 30])).to eq(20)
+    end
+  end
+
+  describe 'combinaisons' do
+    it 'permet l\'arithmétique entre agrégats de plusieurs arrays' do
+      result = calculator.evaluate!('SUM(a) - SUM(b)', a: [100, 200, 50], b: [150])
+      expect(result).to eq(200)
+    end
+  end
+
+  describe 'cas limites' do
+    it 'gère un array avec un seul élément' do
+      expect(calculator.evaluate!('SUM(arr)', arr: [42])).to eq(42)
+      expect(calculator.evaluate!('COUNT(arr)', arr: [42])).to eq(1)
+      expect(calculator.evaluate!('MAX(arr)', arr: [42])).to eq(42)
+    end
+  end
+end

--- a/spec/models/champs/formule_cascade_audit_spec.rb
+++ b/spec/models/champs/formule_cascade_audit_spec.rb
@@ -348,4 +348,56 @@ RSpec.describe 'Formule cascade refresh_formulas_after', type: :model do
       expect(find_champ(dossier, nb_tdc).reload.read_attribute(:value)).to eq('1')
     end
   end
+
+  # ----------------------------------------------------------------------
+  # Scénario : agrégat d'une FORMULE-LIGNE (test opérationnel pour la refonte)
+  # ----------------------------------------------------------------------
+  # pf: Total = SOMME({Lignes/Montant TTC}) où Montant TTC = Prix HT × 2 (formule
+  # par ligne). Vérifie que modifier UNE source recalcule la formule-ligne PUIS
+  # l'agrégat, SANS corrompre les autres lignes. Non-régression de la fuite
+  # value_overrides (keyé stable_id, row-aveugle) : l'override d'une ligne ne
+  # doit pas s'appliquer aux autres lignes lors du recalcul des formules-ligne.
+  describe 'agrégat d\'une formule-ligne (valeurs par ligne distinctes)' do
+    let(:procedure) do
+      create(:procedure, :published, types_de_champ_public: [
+        {
+          type: :repetition, libelle: 'Lignes', mandatory: false, children: [
+            { type: :integer_number, libelle: 'Prix HT' },
+            { type: :formule, libelle: 'Montant TTC' },
+          ],
+        },
+        { type: :formule, libelle: 'Total' },
+      ])
+    end
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:bloc_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Lignes' } }
+    let(:prix_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Prix HT' } }
+    let(:ttc_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Montant TTC' } }
+    let(:total_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Total' } }
+
+    before do
+      set_formule_expression(dossier, ttc_tdc, "{tdc#{prix_tdc.stable_id}} * 2")
+      set_formule_expression(dossier, total_tdc, "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{ttc_tdc.stable_id}})")
+    end
+
+    def add_row_prix(prix)
+      row_id = dossier.repetition_add_row(bloc_tdc, updated_by: 'test')
+      dossier.champ_for_update(prix_tdc, row_id:, updated_by: 'test').update!(value: prix.to_s)
+      row_id
+    end
+
+    it 'modifier la source d\'une ligne recalcule l\'agrégat sans corrompre les autres lignes' do
+      row1 = add_row_prix(100) # TTC 200
+      add_row_prix(200)        # TTC 400
+      dossier.compute_formulas_in_order
+      expect(find_champ(dossier, total_tdc).reload.read_attribute(:value)).to eq('600')
+
+      # row1 Prix HT 100 → 150 : TTC row1 = 300, row2 reste 400 ⇒ Total 700
+      p1 = dossier.champ_for_update(prix_tdc, row_id: row1, updated_by: 'test')
+      p1.update!(value: '150')
+      dossier.refresh_formulas_after(p1)
+
+      expect(find_champ(dossier, total_tdc).reload.read_attribute(:value)).to eq('700')
+    end
+  end
 end

--- a/spec/models/champs/formule_cascade_audit_spec.rb
+++ b/spec/models/champs/formule_cascade_audit_spec.rb
@@ -272,4 +272,80 @@ RSpec.describe 'Formule cascade refresh_formulas_after', type: :model do
       expect { source_champ.update!(value: '50') }.not_to raise_error
     end
   end
+
+  # ----------------------------------------------------------------------
+  # Scénario : formule-agrégat sur bloc répétable (étape E du chantier)
+  # ----------------------------------------------------------------------
+  # pf: Une formule HORS bloc agrège un sous-champ de toutes les lignes
+  # (SOMME({Lignes/Prix HT})) ou compte les lignes (NB({Lignes})). Sa
+  # dépendance est enregistrée au niveau BLOC (granularité bloc). On vérifie
+  # que la cascade explicite la recalcule dans les 3 déclencheurs :
+  #   - modification d'un sous-champ d'une ligne existante
+  #   - ajout d'une ligne
+  #   - suppression d'une ligne
+  describe 'agrégat sur bloc répétable' do
+    let(:procedure) do
+      create(:procedure, :published, types_de_champ_public: [
+        {
+          type: :repetition, libelle: 'Lignes', mandatory: false, children: [
+            { type: :integer_number, libelle: 'Prix HT' },
+          ],
+        },
+        { type: :formule, libelle: 'Total' },
+        { type: :formule, libelle: 'Nb lignes' },
+      ])
+    end
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:bloc_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Lignes' } }
+    let(:prix_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Prix HT' } }
+    let(:total_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Total' } }
+    let(:nb_tdc) { procedure.active_revision.types_de_champ.find { _1.libelle == 'Nb lignes' } }
+
+    def add_row(prix)
+      row_id = dossier.repetition_add_row(bloc_tdc, updated_by: 'test')
+      # pf: simule le flux controller — la saisie du sous-champ déclenche elle
+      # aussi refresh_formulas_after (repetition_add_row ne refresh qu'à l'ajout,
+      # quand le sous-champ est encore vide).
+      sub = dossier.champ_for_update(prix_tdc, row_id:, updated_by: 'test')
+      sub.update!(value: prix.to_s)
+      dossier.refresh_formulas_after(sub)
+      row_id
+    end
+
+    before do
+      set_formule_expression(dossier, total_tdc, "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{prix_tdc.stable_id}})")
+      set_formule_expression(dossier, nb_tdc, "COUNT({tdc#{bloc_tdc.stable_id}})")
+    end
+
+    it 'recalcule SOMME et NB à l\'ajout d\'une ligne' do
+      add_row(100)
+      add_row(200)
+      expect(find_champ(dossier, total_tdc).reload.read_attribute(:value)).to eq('300')
+      expect(find_champ(dossier, nb_tdc).reload.read_attribute(:value)).to eq('2')
+    end
+
+    it 'recalcule SOMME à la modification d\'un sous-champ d\'une ligne existante' do
+      row_id = add_row(100)
+      add_row(200)
+      expect(find_champ(dossier, total_tdc).reload.read_attribute(:value)).to eq('300')
+
+      # modification d'un sous-champ de la 1ʳᵉ ligne → l'agrégat (dépendance
+      # niveau bloc) doit se recalculer même si sa dépendance directe est le bloc
+      sub_champ = dossier.champ_for_update(prix_tdc, row_id:, updated_by: 'test')
+      sub_champ.update!(value: '150')
+      dossier.refresh_formulas_after(sub_champ)
+
+      expect(find_champ(dossier, total_tdc).reload.read_attribute(:value)).to eq('350')
+    end
+
+    it 'recalcule SOMME et NB à la suppression d\'une ligne' do
+      add_row(100)
+      row2 = add_row(200)
+      expect(find_champ(dossier, total_tdc).reload.read_attribute(:value)).to eq('300')
+
+      dossier.repetition_remove_row(bloc_tdc, row2, updated_by: 'test')
+      expect(find_champ(dossier, total_tdc).reload.read_attribute(:value)).to eq('100')
+      expect(find_champ(dossier, nb_tdc).reload.read_attribute(:value)).to eq('1')
+    end
+  end
 end

--- a/spec/models/types_de_champ/formule_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/formule_type_de_champ_spec.rb
@@ -446,6 +446,36 @@ describe TypesDeChamp::FormuleTypeDeChamp do
       end
     end
 
+    # pf: étape D du chantier agrégat — une formule-agrégat référence un bloc
+    # répétable via {tdc<bloc>} ou un de ses sous-champs via {tdc<bloc>/sub_<id>}.
+    # Dans les deux cas, c'est le stable_id du BLOC qui doit être enregistré
+    # comme dépendance (granularité bloc : toute modif d'une ligne ou ajout/
+    # suppression recalcule l'agrégat). Le path /sub_<id> est ignoré comme
+    # n'importe quel suffixe.
+    context 'with a repetition aggregate reference {tdc<bloc>/sub_<id>}' do
+      let(:expression) { 'SOMME({tdc100/sub_101})' }
+
+      it 'stores the bloc stable_id (not the sub-champ)' do
+        expect(deps['champs']).to eq([100])
+      end
+    end
+
+    context 'with a bare bloc reference {tdc<bloc>}' do
+      let(:expression) { 'NB({tdc100})' }
+
+      it 'stores the bloc stable_id' do
+        expect(deps['champs']).to eq([100])
+      end
+    end
+
+    context 'mixing aggregate refs of the same bloc' do
+      let(:expression) { 'SOMME({tdc100/sub_101}) - SOMME({tdc100/sub_102})' }
+
+      it 'deduplicates to a single bloc dependency' do
+        expect(deps['champs']).to eq([100])
+      end
+    end
+
     context 'with AUJOURDHUI() (clock function)' do
       let(:expression) { 'AUJOURDHUI() + DUREE_JOURS(7)' }
 

--- a/spec/services/formula_ai_prompt_service_spec.rb
+++ b/spec/services/formula_ai_prompt_service_spec.rb
@@ -31,6 +31,18 @@ describe FormulaAiPromptService do
       expect(subject).to include('DUREE_SEMAINES')
     end
 
+    it 'documents l’agrégation sur blocs répétables et les nouvelles fonctions' do
+      expect(subject).to include('Agrégation sur blocs répétables')
+      expect(subject).to include('SOMME({Lignes de facture/Prix HT})')
+      expect(subject).to include('NB({Lignes de facture})')
+      expect(subject).to include('JOINDRE')
+      expect(subject).to include('MEDIANE')
+      # la formule-agrégat doit être placée APRÈS le bloc
+      expect(subject).to match(/APRÈS le bloc/)
+      # plus de mention "agrégat impossible"
+      expect(subject).not_to include('Aucun agrégat global n’est possible')
+    end
+
     context 'when output_type is "date"' do
       let(:output_type) { 'date' }
 

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -1014,4 +1014,183 @@ describe FormulaCalculationService do
       end
     end
   end
+
+  # pf: chantier formule-agrégat — une formule placée hors bloc peut agréger
+  # un sous-champ de toutes les lignes via {bloc/sub}, ou compter le bloc
+  # via {bloc}. Cf. docs/superpowers/specs/2026-05-21-formule-repetitions-design.md
+  describe '#compute_value with aggregation over a repetition block' do
+    let(:procedure) do
+      create(:procedure, :published, types_de_champ_public: [
+        {
+          type: :repetition, libelle: 'Lignes', mandatory: false, children: [
+            { type: :text, libelle: 'Désignation' },
+            { type: :integer_number, libelle: 'Prix HT' },
+          ],
+        },
+        { type: :formule, libelle: 'Total' },
+      ])
+    end
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:revision) { procedure.active_revision }
+    let(:bloc_tdc) { revision.types_de_champ.find { _1.libelle == 'Lignes' } }
+    let(:prix_ht_tdc) { revision.types_de_champ.find { _1.libelle == 'Prix HT' } }
+    let(:formule_tdc) { revision.types_de_champ.find { _1.libelle == 'Total' } }
+    let(:formule_champ) { dossier.project_champs_public.find { _1.stable_id == formule_tdc.stable_id } }
+    let(:service) { described_class.new(dossier) }
+
+    def add_row_with_prix_ht(value)
+      row_id = dossier.repetition_add_row(bloc_tdc, updated_by: 'test')
+      if value
+        # pf: repetition_add_row crée juste le RepetitionChamp pour le row_id ;
+        # les sous-champs sont créés à la demande via champ_for_update.
+        sub_champ = dossier.champ_for_update(prix_ht_tdc, row_id: row_id, updated_by: 'test')
+        sub_champ.update!(value: value.to_s)
+      end
+      row_id
+    end
+
+    def set_formula(expression)
+      formule_tdc.update!(formule_expression: expression)
+    end
+
+    def sub_ref
+      "tdc#{bloc_tdc.stable_id}/sub_#{prix_ht_tdc.stable_id}"
+    end
+
+    def bloc_ref
+      "tdc#{bloc_tdc.stable_id}"
+    end
+
+    context 'SOMME sur un sous-champ numérique' do
+      before do
+        add_row_with_prix_ht(100)
+        add_row_with_prix_ht(200)
+        add_row_with_prix_ht(50)
+      end
+
+      it 'somme les prix de toutes les lignes' do
+        set_formula("SOMME({#{sub_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('350')
+      end
+    end
+
+    context 'COUNT sur le bloc entier' do
+      before do
+        add_row_with_prix_ht(100)
+        add_row_with_prix_ht(200)
+        add_row_with_prix_ht(50)
+      end
+
+      it 'compte le nombre de lignes' do
+        set_formula("COUNT({#{bloc_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('3')
+      end
+    end
+
+    context 'MAX et MIN sur un sous-champ' do
+      before do
+        add_row_with_prix_ht(100)
+        add_row_with_prix_ht(200)
+        add_row_with_prix_ht(50)
+      end
+
+      it 'MAX retourne le plus grand' do
+        set_formula("MAX({#{sub_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('200')
+      end
+
+      it 'MIN retourne le plus petit' do
+        set_formula("MIN({#{sub_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('50')
+      end
+    end
+
+    context 'MOYENNE sur un sous-champ' do
+      before do
+        add_row_with_prix_ht(100)
+        add_row_with_prix_ht(200)
+        add_row_with_prix_ht(150)
+      end
+
+      it 'retourne la moyenne arithmétique' do
+        set_formula("MOYENNE({#{sub_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('150')
+      end
+    end
+
+    context 'bloc vide' do
+      it 'SOMME retourne 0' do
+        set_formula("SOMME({#{sub_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('0')
+      end
+
+      it 'COUNT retourne 0' do
+        set_formula("COUNT({#{bloc_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('0')
+      end
+
+      # pf: Dentaku natif MAX/[] = nil (cf. spec sentinelle dentaku_array_functions).
+      # Le service propage le nil → champ formule reste vide (pas d'erreur).
+      it 'MAX retourne nil (rien à comparer)' do
+        set_formula("MAX({#{sub_ref}})")
+        expect(service.compute_value(formule_champ)).to be_nil
+      end
+    end
+
+    context 'ligne avec sous-champ vide' do
+      before do
+        add_row_with_prix_ht(100)
+        add_row_with_prix_ht(nil) # ligne sans Prix HT saisi
+        add_row_with_prix_ht(50)
+      end
+
+      it 'SOMME ignore les valeurs nil (somme les 2 lignes valides)' do
+        set_formula("SOMME({#{sub_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('150')
+      end
+
+      it 'COUNT compte toutes les lignes (3) — la cardinalité ne dépend pas des nil' do
+        set_formula("COUNT({#{bloc_ref}})")
+        expect(service.compute_value(formule_champ)).to eq('3')
+      end
+    end
+
+    context 'combinaison : reste à payer' do
+      let(:procedure) do
+        create(:procedure, :published, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'Lignes', mandatory: false, children: [
+              { type: :integer_number, libelle: 'Prix HT' },
+            ],
+          },
+          {
+            type: :repetition, libelle: 'Paiements', mandatory: false, children: [
+              { type: :integer_number, libelle: 'Montant' },
+            ],
+          },
+          { type: :formule, libelle: 'Total' },
+        ])
+      end
+      let(:paiement_tdc) { revision.types_de_champ.find { _1.libelle == 'Paiements' } }
+      let(:montant_tdc) { revision.types_de_champ.find { _1.libelle == 'Montant' } }
+
+      def add_paiement(value)
+        row_id = dossier.repetition_add_row(paiement_tdc, updated_by: 'test')
+        sub_champ = dossier.champ_for_update(montant_tdc, row_id: row_id, updated_by: 'test')
+        sub_champ.update!(value: value.to_s)
+      end
+
+      it 'SOMME(lignes/prix) - SOMME(paiements/montant) = reste à payer' do
+        add_row_with_prix_ht(100)
+        add_row_with_prix_ht(200)
+        add_paiement(150)
+
+        sub_prix = "tdc#{bloc_tdc.stable_id}/sub_#{prix_ht_tdc.stable_id}"
+        sub_montant = "tdc#{paiement_tdc.stable_id}/sub_#{montant_tdc.stable_id}"
+
+        set_formula("SOMME({#{sub_prix}}) - SOMME({#{sub_montant}})")
+        expect(service.compute_value(formule_champ)).to eq('150')
+      end
+    end
+  end
 end

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -1254,5 +1254,49 @@ describe FormulaCalculationService do
         expect(service.compute_value(formule_champ)).to eq('150')
       end
     end
+
+    # pf: agréger un sous-champ FORMULE (formule-ligne dans le bloc) — son
+    # résultat est stocké en string, il faut le coercer selon formule_output_type
+    # (sinon SOMME("200") = 0). Pattern du catalogue : transformation par ligne
+    # via formule-ligne intermédiaire, puis agrégation extérieure.
+    context 'agrégation sur un sous-champ formule-ligne' do
+      let(:procedure) do
+        create(:procedure, :published, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'Lignes', mandatory: false, children: [
+              { type: :integer_number, libelle: 'Prix HT' },
+              { type: :formule, libelle: 'Montant TTC' },
+            ],
+          },
+          { type: :formule, libelle: 'Total TTC' },
+        ])
+      end
+      let(:ligne_formule_tdc) { revision.types_de_champ.find { _1.libelle == 'Montant TTC' } }
+      let(:total_tdc) { revision.types_de_champ.find { _1.libelle == 'Total TTC' } }
+      let(:total_champ) { dossier.project_champs_public.find { _1.stable_id == total_tdc.stable_id } }
+
+      before do
+        ligne_formule_tdc.update!(formule_expression: "{tdc#{prix_ht_tdc.stable_id}} * 2")
+        total_tdc.update!(formule_expression: "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{ligne_formule_tdc.stable_id}})")
+      end
+
+      def add_row_compute(prix)
+        row_id = dossier.repetition_add_row(bloc_tdc, updated_by: 'test')
+        # pf: instancie les sous-champs de la ligne comme le fait l'UI à l'ajout
+        # (formule-ligne incluse — sans son champ persisté, formule_champs_for_tdc
+        # ne la calcule pas : return [] if tdc.child?).
+        dossier.champ_for_update(ligne_formule_tdc, row_id:, updated_by: 'test')
+        sub = dossier.champ_for_update(prix_ht_tdc, row_id:, updated_by: 'test')
+        sub.update!(value: prix.to_s)
+        dossier.refresh_formulas_after(sub) # calcule la formule-ligne de cette row
+        row_id
+      end
+
+      it 'somme les résultats de la formule-ligne de chaque ligne' do
+        add_row_compute(100) # Montant TTC = 200
+        add_row_compute(50)  # Montant TTC = 100
+        expect(service.compute_value(total_champ)).to eq('300')
+      end
+    end
   end
 end

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -78,6 +78,47 @@ describe FormulaCalculationService do
       # and SOMME receives it as a single array argument, which flatten() handles
     end
 
+    # pf: étape H du chantier agrégat — alias FR additionnels.
+    context 'alias FR additionnels (NB, COMPTE, RACINE, PLANCHER, PLAFOND, MEDIANE, JOINDRE)' do
+      let(:formule_champ) { Champs::FormuleChamp.new(dossier: dossier) }
+
+      def compute(expression)
+        allow(formule_champ).to receive(:type_de_champ).and_return(build(:type_de_champ_formule, formule_expression: expression))
+        service.compute_value(formule_champ)
+      end
+
+      it 'NB compte les arguments' do
+        expect(compute('NB(1, 2, 3)')).to eq('3')
+      end
+
+      it 'COMPTE est un synonyme de NB' do
+        expect(compute('COMPTE(1, 2, 3, 4)')).to eq('4')
+      end
+
+      it 'RACINE calcule la racine carrée' do
+        expect(compute('RACINE(16)')).to eq('4')
+      end
+
+      it 'PLANCHER arrondit vers le bas (floor)' do
+        expect(compute('PLANCHER(3.7)')).to eq('3')
+      end
+
+      it 'PLAFOND arrondit vers le haut (ceil)' do
+        expect(compute('PLAFOND(3.2)')).to eq('4')
+      end
+
+      it 'MEDIANE (nombre impair de valeurs) retourne la valeur centrale' do
+        expect(compute('MEDIANE(1, 2, 3, 4, 5)')).to eq('3')
+      end
+
+      it 'MEDIANE (nombre pair de valeurs) retourne la moyenne des deux centrales' do
+        expect(compute('MEDIANE(1, 2, 3, 4)')).to eq('2.5')
+      end
+
+      # pf: JOINDRE(array, separator) — testé en contexte agrégat (son usage
+      # réel : JOINDRE({bloc/sous-champ}, ", ")), cf. describe agrégation.
+    end
+
     context 'ARRONDI_INF, ARRONDI_SUP, ENTIER functions' do
       let(:formule_champ) { Champs::FormuleChamp.new(dossier: dossier) }
 
@@ -1084,6 +1125,27 @@ describe FormulaCalculationService do
       it 'compte le nombre de lignes' do
         set_formula("COUNT({#{bloc_ref}})")
         expect(service.compute_value(formule_champ)).to eq('3')
+      end
+    end
+
+    context 'JOINDRE sur un sous-champ texte (Désignation)' do
+      let(:designation_tdc) { revision.types_de_champ.find { _1.libelle == 'Désignation' } }
+
+      def add_row_with_designation(label)
+        row_id = dossier.repetition_add_row(bloc_tdc, updated_by: 'test')
+        dossier.champ_for_update(designation_tdc, row_id:, updated_by: 'test').update!(value: label)
+        row_id
+      end
+
+      before do
+        add_row_with_designation('Pommes')
+        add_row_with_designation('Poires')
+        add_row_with_designation('Bananes')
+      end
+
+      it 'concatène les désignations de toutes les lignes' do
+        set_formula("JOINDRE({tdc#{bloc_tdc.stable_id}/sub_#{designation_tdc.stable_id}}, \", \")")
+        expect(service.compute_value(formule_champ)).to eq('Pommes, Poires, Bananes')
       end
     end
 

--- a/spec/services/formula_calculation_service_spec.rb
+++ b/spec/services/formula_calculation_service_spec.rb
@@ -1280,21 +1280,19 @@ describe FormulaCalculationService do
         total_tdc.update!(formule_expression: "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{ligne_formule_tdc.stable_id}})")
       end
 
-      def add_row_compute(prix)
+      # pf: on NE crée PAS le champ formule-ligne (Montant TTC) : c'est le cas
+      # réel — la cascade ne persiste pas les champs formule enfants d'un bloc
+      # (return [] if tdc.child?), et en preview ils n'existent que matérialisés.
+      # L'agrégat doit donc recalculer la formule-ligne à la volée par ligne.
+      def add_row_with_prix(prix)
         row_id = dossier.repetition_add_row(bloc_tdc, updated_by: 'test')
-        # pf: instancie les sous-champs de la ligne comme le fait l'UI à l'ajout
-        # (formule-ligne incluse — sans son champ persisté, formule_champs_for_tdc
-        # ne la calcule pas : return [] if tdc.child?).
-        dossier.champ_for_update(ligne_formule_tdc, row_id:, updated_by: 'test')
-        sub = dossier.champ_for_update(prix_ht_tdc, row_id:, updated_by: 'test')
-        sub.update!(value: prix.to_s)
-        dossier.refresh_formulas_after(sub) # calcule la formule-ligne de cette row
+        dossier.champ_for_update(prix_ht_tdc, row_id:, updated_by: 'test').update!(value: prix.to_s)
         row_id
       end
 
-      it 'somme les résultats de la formule-ligne de chaque ligne' do
-        add_row_compute(100) # Montant TTC = 200
-        add_row_compute(50)  # Montant TTC = 100
+      it 'somme les résultats de la formule-ligne (non persistée) de chaque ligne' do
+        add_row_with_prix(100) # Montant TTC = 200
+        add_row_with_prix(50)  # Montant TTC = 100
         expect(service.compute_value(total_champ)).to eq('300')
       end
     end

--- a/spec/services/formula_column_resolver_spec.rb
+++ b/spec/services/formula_column_resolver_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+describe FormulaColumnResolver do
+  describe 'résolution des références scalaires (cas existants — non régression)' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :text, libelle: 'Référence' },
+        { type: :integer_number, libelle: 'Montant' },
+      ])
+    end
+    let(:revision) { procedure.active_revision || procedure.draft_revision }
+    let(:resolver) { described_class.new(revision) }
+    let(:reference_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Référence' } }
+    let(:montant_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Montant' } }
+
+    it 'résout un tdc<N> vers la Column champ scalaire' do
+      result = resolver.resolve("tdc#{reference_tdc.stable_id}")
+      expect(result).to be_a(Columns::ChampColumn)
+      expect(result.stable_id).to eq(reference_tdc.stable_id)
+    end
+
+    it 'résout une référence inconnue vers nil' do
+      expect(resolver.resolve('tdc99999999')).to be_nil
+    end
+
+    it 'résout une colonne système' do
+      expect(resolver.resolve('dossier_number')).not_to be_nil
+    end
+  end
+
+  describe 'résolution des blocs répétables (étape A — formules-agrégat)' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :text, libelle: 'Référence dossier' },
+        {
+          type: :repetition, libelle: 'Lignes de facture', children: [
+            { type: :text, libelle: 'Désignation' },
+            { type: :integer_number, libelle: 'Prix HT' },
+            { type: :integer_number, libelle: 'Quantité' },
+          ],
+        },
+      ])
+    end
+    let(:revision) { procedure.active_revision || procedure.draft_revision }
+    let(:resolver) { described_class.new(revision) }
+    let(:bloc_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Lignes de facture' } }
+    let(:prix_ht_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Prix HT' } }
+    let(:quantite_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Quantité' } }
+
+    context 'référence au bloc seul {tdc<bloc>}' do
+      it 'résout vers une RepetitionRef qui porte le TDC bloc' do
+        result = resolver.resolve("tdc#{bloc_tdc.stable_id}")
+        expect(result).to be_a(FormulaColumnResolver::RepetitionRef)
+        expect(result.bloc_tdc.stable_id).to eq(bloc_tdc.stable_id)
+        expect(result.bloc_tdc).to be_repetition
+      end
+    end
+
+    context 'référence à un sous-champ {tdc<bloc>/sub_<sub>}' do
+      it 'résout vers une RepetitionSubChampRef qui porte bloc + sous-tdc' do
+        ref = "tdc#{bloc_tdc.stable_id}/sub_#{prix_ht_tdc.stable_id}"
+        result = resolver.resolve(ref)
+
+        expect(result).to be_a(FormulaColumnResolver::RepetitionSubChampRef)
+        expect(result.bloc_tdc.stable_id).to eq(bloc_tdc.stable_id)
+        expect(result.sub_tdc.stable_id).to eq(prix_ht_tdc.stable_id)
+      end
+
+      it 'fonctionne pour chaque sous-champ du bloc' do
+        ref = "tdc#{bloc_tdc.stable_id}/sub_#{quantite_tdc.stable_id}"
+        result = resolver.resolve(ref)
+
+        expect(result).to be_a(FormulaColumnResolver::RepetitionSubChampRef)
+        expect(result.sub_tdc.stable_id).to eq(quantite_tdc.stable_id)
+      end
+    end
+
+    context 'référence à un sous-champ d\'un bloc inconnu' do
+      it 'résout vers nil' do
+        expect(resolver.resolve('tdc99999/sub_42')).to be_nil
+      end
+    end
+
+    context 'référence à un sous-champ inexistant dans un bloc connu' do
+      it 'résout vers nil' do
+        expect(resolver.resolve("tdc#{bloc_tdc.stable_id}/sub_99999")).to be_nil
+      end
+    end
+
+    context 'co-existence avec la résolution scalaire des sous-TDC' do
+      it 'permet aussi la résolution directe d\'un sous-TDC via tdc<sub> (formules-ligne)' do
+        # Une formule-ligne dans le bloc utilise tdc<sub> directement.
+        # Le chantier #3 n'altère pas ce comportement.
+        result = resolver.resolve("tdc#{prix_ht_tdc.stable_id}")
+        expect(result).to be_a(Columns::ChampColumn)
+        expect(result.stable_id).to eq(prix_ht_tdc.stable_id)
+      end
+    end
+  end
+
+  describe '#resolve_with_path' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :commune_de_polynesie, libelle: 'Code postal' },
+        {
+          type: :repetition, libelle: 'Lignes', children: [
+            { type: :integer_number, libelle: 'Prix HT' },
+          ],
+        },
+      ])
+    end
+    let(:revision) { procedure.active_revision || procedure.draft_revision }
+    let(:resolver) { described_class.new(revision) }
+    let(:commune_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Code postal' } }
+    let(:bloc_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Lignes' } }
+    let(:prix_ht_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Prix HT' } }
+
+    it 'résout un sous-champ de bloc vers [RepetitionSubChampRef, nil]' do
+      ref = "tdc#{bloc_tdc.stable_id}/sub_#{prix_ht_tdc.stable_id}"
+      target, path = resolver.resolve_with_path(ref)
+
+      expect(target).to be_a(FormulaColumnResolver::RepetitionSubChampRef)
+      expect(path).to be_nil
+    end
+
+    it 'préserve le contrat [Column, :path_symbol] pour les références non-bloc' do
+      # Cas historique : {tdc<N>/path} où le TDC n'est PAS un bloc répétable
+      # (ex: commune, DN, dropdown lié...). Le path doit être retourné comme
+      # symbole, et la résolution du column_id seul ne doit pas être altérée.
+      ref = "tdc#{commune_tdc.stable_id}/commune"
+      target, path = resolver.resolve_with_path(ref)
+
+      # target peut être un Columns::* selon le type ; ce qui compte :
+      # ce n'est PAS un RepetitionSubChampRef, et le path est un Symbol.
+      expect(target).not_to be_a(FormulaColumnResolver::RepetitionSubChampRef)
+      expect(path).to be_a(Symbol)
+      expect(path).to eq(:commune)
+    end
+  end
+end

--- a/spec/services/formula_expression_service_spec.rb
+++ b/spec/services/formula_expression_service_spec.rb
@@ -144,4 +144,31 @@ describe FormulaExpressionService do
       expect(result).to eq('{Commune} + {DN} + {dossier_number}')
     end
   end
+
+  # pf: agrégat sur bloc répétable — l'interne {tdc<bloc>/sub_<sub_id>} doit
+  # se réafficher en {Bloc/Sous-champ} dans l'éditeur (sinon l'admin voit le brut).
+  describe '.convert_to_libelles avec agrégat de bloc répétable' do
+    let(:bloc_tdc) { build(:type_de_champ, type_champ: :repetition, stable_id: 100, libelle: 'Facture') }
+    let(:prix_tdc) { build(:type_de_champ, type_champ: :integer_number, stable_id: 101, libelle: 'Prix HT') }
+    let(:revision) { build(:procedure_revision) }
+
+    before do
+      allow(revision).to receive(:types_de_champ).and_return([bloc_tdc, prix_tdc])
+    end
+
+    it 'convertit {tdc100/sub_101} en {Facture/Prix HT}' do
+      result = FormulaExpressionService.convert_to_libelles('SOMME({tdc100/sub_101})', revision)
+      expect(result).to eq('SOMME({Facture/Prix HT})')
+    end
+
+    it 'convertit {tdc100} (bloc nu) en {Facture}' do
+      result = FormulaExpressionService.convert_to_libelles('NB({tdc100})', revision)
+      expect(result).to eq('NB({Facture})')
+    end
+
+    it 'laisse le brut si le sous-champ est inconnu' do
+      result = FormulaExpressionService.convert_to_libelles('SOMME({tdc100/sub_99999})', revision)
+      expect(result).to eq('SOMME({tdc100/sub_99999})')
+    end
+  end
 end

--- a/spec/system/users/formula_repetition_aggregate_spec.rb
+++ b/spec/system/users/formula_repetition_aggregate_spec.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
-# pf: S5/S6 — Agrégation d'un sous-champ de bloc répétable (chantier
-# formule-agrégat). Vérifie la chaîne UI → controller → refresh_formulas_after
-# → display de bout en bout :
-#   - S5 : l'agrégat s'affiche correctement pour un dossier déjà rempli
-#   - S6 : modifier un sous-champ d'une ligne via l'UI recalcule l'agrégat
+# pf: S5/S6 — Agrégation d'une FORMULE-LIGNE de bloc répétable (chantier
+# formule-agrégat). Le bloc contient Prix HT (saisi) + Montant TTC (formule-ligne
+# = Prix HT × 2) ; l'agrégat hors bloc somme la formule-ligne :
+#   Total = SOMME({Lignes/Montant TTC}).
+# On vérifie toute la chaîne UI → controller → refresh_formulas_after →
+# (recalcul formule-ligne par ligne) → agrégat → display :
+#   - S5 : affichage de l'agrégat pour un dossier pré-rempli
+#   - S6 : modifier la valeur source d'une ligne recalcule la formule-ligne
+#          PUIS l'agrégat.
 #
-# pf: les lignes sont pré-remplies via le MODÈLE (déterministe). L'ajout de
-# plusieurs lignes via l'UI puis saisie immédiate est une zone de flakiness
-# autosave/Turbo pré-existante (course re-render) hors périmètre de ce chantier ;
-# on teste donc le déclencheur de recalcul le plus à risque (modification d'un
-# sous-champ existant), pas l'ajout multi-lignes via l'UI.
+# pf: ce S6 (agrégat d'une formule-ligne) est aussi le test opérationnel de
+# référence pour la refonte « passe accumulante » (cf.
+# docs/superpowers/specs/2026-05-28-formule-passe-accumulante-design.md) : il
+# doit rester vert quel que soit le mécanisme (recalcul à la volée actuel ou
+# accumulateur futur).
+#
+# pf: lignes pré-remplies via le MODÈLE (déterministe). L'ajout multi-lignes via
+# l'UI puis saisie immédiate est une zone de flakiness autosave/Turbo
+# pré-existante (course re-render), hors périmètre de ce chantier.
 describe 'Formula aggregate over a repetition block', js: true do
   let(:password) { SECURE_PASSWORD }
   let!(:user) { create(:user, password: password) }
@@ -20,6 +28,7 @@ describe 'Formula aggregate over a repetition block', js: true do
       {
         type: :repetition, libelle: 'Lignes de facture', mandatory: false, children: [
           { type: :integer_number, libelle: 'Prix HT' },
+          { type: :formule, libelle: 'Montant TTC' },
         ],
       },
       { type: :formule, libelle: 'Total' },
@@ -30,12 +39,17 @@ describe 'Formula aggregate over a repetition block', js: true do
   let(:revision) { procedure.active_revision }
   let(:bloc_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Lignes de facture' } }
   let(:prix_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Prix HT' } }
+  let(:ttc_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Montant TTC' } }
   let(:total_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Total' } }
 
   before do
-    total_tdc.update!(formule_expression: "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{prix_tdc.stable_id}})")
+    # formule-ligne (intra-ligne) : Montant TTC = Prix HT × 2
+    ttc_tdc.update!(formule_expression: "{tdc#{prix_tdc.stable_id}} * 2")
+    # agrégat hors bloc : Total = SOMME des Montant TTC de toutes les lignes
+    total_tdc.update!(formule_expression: "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{ttc_tdc.stable_id}})")
 
-    # pré-remplir 2 lignes via le modèle (100, 200) + calcul initial de l'agrégat
+    # pré-remplir 2 lignes via le modèle : Prix HT 100 et 200
+    # → Montant TTC 200 et 400 → Total = 600
     [100, 200].each do |v|
       row_id = user_dossier.repetition_add_row(bloc_tdc, updated_by: 'setup')
       user_dossier.champ_for_update(prix_tdc, row_id:, updated_by: 'setup').update!(value: v.to_s)
@@ -47,22 +61,22 @@ describe 'Formula aggregate over a repetition block', js: true do
     find('.dom-ready')
   end
 
-  scenario 'S5 — l’agrégat affiche la somme des lignes pré-remplies' do
-    expect(total_value).to eq(300)
+  scenario 'S5 — l’agrégat somme la formule-ligne de chaque ligne (600)' do
+    expect(total_value).to eq(600)
   end
 
-  scenario 'S6 — modifier un sous-champ d’une ligne recalcule l’agrégat' do
-    expect(total_value).to eq(300)
+  scenario 'S6 — modifier la source d’une ligne recalcule la formule-ligne puis l’agrégat' do
+    expect(total_value).to eq(600)
 
-    # 1re ligne : 100 → 150
+    # 1re ligne : Prix HT 100 → 150  ⇒ Montant TTC 200 → 300  ⇒ Total 600 → 700
     within '.repetition .champs-group:first-child' do
       fill_in('Prix HT', with: '150')
       blur
     end
     wait_for_autosave
 
-    wait_until { total_value == 350 }
-    expect(total_value).to eq(350)
+    wait_until { total_value == 700 }
+    expect(total_value).to eq(700)
   end
 
   private

--- a/spec/system/users/formula_repetition_aggregate_spec.rb
+++ b/spec/system/users/formula_repetition_aggregate_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# pf: S5/S6 — Agrégation d'un sous-champ de bloc répétable (chantier
+# formule-agrégat). Vérifie la chaîne UI → controller → refresh_formulas_after
+# → display de bout en bout :
+#   - S5 : l'agrégat s'affiche correctement pour un dossier déjà rempli
+#   - S6 : modifier un sous-champ d'une ligne via l'UI recalcule l'agrégat
+#
+# pf: les lignes sont pré-remplies via le MODÈLE (déterministe). L'ajout de
+# plusieurs lignes via l'UI puis saisie immédiate est une zone de flakiness
+# autosave/Turbo pré-existante (course re-render) hors périmètre de ce chantier ;
+# on teste donc le déclencheur de recalcul le plus à risque (modification d'un
+# sous-champ existant), pas l'ajout multi-lignes via l'UI.
+describe 'Formula aggregate over a repetition block', js: true do
+  let(:password) { SECURE_PASSWORD }
+  let!(:user) { create(:user, password: password) }
+
+  let!(:procedure) do
+    create(:procedure, :published, :for_individual, types_de_champ_public: [
+      {
+        type: :repetition, libelle: 'Lignes de facture', mandatory: false, children: [
+          { type: :integer_number, libelle: 'Prix HT' },
+        ],
+      },
+      { type: :formule, libelle: 'Total' },
+    ])
+  end
+
+  let!(:user_dossier) { create(:dossier, :brouillon, :with_individual, procedure:, user:) }
+  let(:revision) { procedure.active_revision }
+  let(:bloc_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Lignes de facture' } }
+  let(:prix_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Prix HT' } }
+  let(:total_tdc) { revision.types_de_champ.find { |t| t.libelle == 'Total' } }
+
+  before do
+    total_tdc.update!(formule_expression: "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{prix_tdc.stable_id}})")
+
+    # pré-remplir 2 lignes via le modèle (100, 200) + calcul initial de l'agrégat
+    [100, 200].each do |v|
+      row_id = user_dossier.repetition_add_row(bloc_tdc, updated_by: 'setup')
+      user_dossier.champ_for_update(prix_tdc, row_id:, updated_by: 'setup').update!(value: v.to_s)
+    end
+    user_dossier.compute_formulas_in_order
+
+    login_as user, scope: :user
+    visit brouillon_dossier_path(user_dossier)
+    find('.dom-ready')
+  end
+
+  scenario 'S5 — l’agrégat affiche la somme des lignes pré-remplies' do
+    expect(total_value).to eq(300)
+  end
+
+  scenario 'S6 — modifier un sous-champ d’une ligne recalcule l’agrégat' do
+    expect(total_value).to eq(300)
+
+    # 1re ligne : 100 → 150
+    within '.repetition .champs-group:first-child' do
+      fill_in('Prix HT', with: '150')
+      blur
+    end
+    wait_for_autosave
+
+    wait_until { total_value == 350 }
+    expect(total_value).to eq(350)
+  end
+
+  private
+
+  # pf: lecture directe en DB (read_attribute) — project_champs est mémoïsé et
+  # renverrait une valeur périmée dans wait_until.
+  def total_value
+    Champ.where(dossier_id: user_dossier.id, stable_id: total_tdc.stable_id, row_id: nil)
+      .first&.read_attribute(:value).to_i
+  end
+end

--- a/spec/validators/types_de_champ/formula_validator_spec.rb
+++ b/spec/validators/types_de_champ/formula_validator_spec.rb
@@ -90,6 +90,52 @@ RSpec.describe TypesDeChamp::FormulaValidator do
     end
   end
 
+  # pf: agrégat sur bloc répétable — {tdc<bloc>} (COUNT) et {tdc<bloc>/sub_<id>} (SOMME).
+  context 'with an aggregate formula referencing a preceding repetition block' do
+    let(:types) do
+      [
+        { type: :repetition, libelle: 'Facture', mandatory: false, children: [
+          { type: :integer_number, libelle: 'Prix HT' },
+        ] },
+        { type: :formule, libelle: 'Total' },
+      ]
+    end
+    let(:revision) { procedure.draft_revision }
+    let(:bloc_tdc) { revision.types_de_champ.find { _1.libelle == 'Facture' } }
+    let(:prix_tdc) { revision.types_de_champ.find { _1.libelle == 'Prix HT' } }
+    let(:formule_tdc) { revision.types_de_champ.find { _1.libelle == 'Total' } }
+
+    it 'accepts NB({bloc}) sans erreur' do
+      formule_tdc.update_column(:options, { 'formule_expression' => "NB({tdc#{bloc_tdc.stable_id}})" })
+      expect { subject }.not_to change { procedure.errors.count }
+    end
+
+    it 'accepts SOMME({bloc/sous-champ}) sans erreur' do
+      formule_tdc.update_column(:options, { 'formule_expression' => "SOMME({tdc#{bloc_tdc.stable_id}/sub_#{prix_tdc.stable_id}})" })
+      expect { subject }.not_to change { procedure.errors.count }
+    end
+  end
+
+  context 'with an aggregate referencing a repetition block placed AFTER the formula' do
+    let(:types) do
+      [
+        { type: :formule, libelle: 'Total' },
+        { type: :repetition, libelle: 'Facture', mandatory: false, children: [
+          { type: :integer_number, libelle: 'Prix HT' },
+        ] },
+      ]
+    end
+    let(:revision) { procedure.draft_revision }
+    let(:bloc_tdc) { revision.types_de_champ.find { _1.libelle == 'Facture' } }
+    let(:formule_tdc) { revision.types_de_champ.find { _1.libelle == 'Total' } }
+
+    it 'adds an error (le bloc ne précède pas la formule)' do
+      formule_tdc.update_column(:options, { 'formule_expression' => "NB({tdc#{bloc_tdc.stable_id}})" })
+      expect { subject }.to change { procedure.errors.count }.by_at_least(1)
+      expect(procedure.errors.full_messages.join).to include('bloc')
+    end
+  end
+
   context 'with a private formula referencing a public champ' do
     let(:procedure) do
       create(:procedure, types_de_champ_public: [

--- a/spec/validators/types_de_champ/formula_validator_spec.rb
+++ b/spec/validators/types_de_champ/formula_validator_spec.rb
@@ -94,9 +94,11 @@ RSpec.describe TypesDeChamp::FormulaValidator do
   context 'with an aggregate formula referencing a preceding repetition block' do
     let(:types) do
       [
-        { type: :repetition, libelle: 'Facture', mandatory: false, children: [
-          { type: :integer_number, libelle: 'Prix HT' },
-        ] },
+        {
+          type: :repetition, libelle: 'Facture', mandatory: false, children: [
+            { type: :integer_number, libelle: 'Prix HT' },
+          ],
+        },
         { type: :formule, libelle: 'Total' },
       ]
     end
@@ -120,9 +122,11 @@ RSpec.describe TypesDeChamp::FormulaValidator do
     let(:types) do
       [
         { type: :formule, libelle: 'Total' },
-        { type: :repetition, libelle: 'Facture', mandatory: false, children: [
-          { type: :integer_number, libelle: 'Prix HT' },
-        ] },
+        {
+          type: :repetition, libelle: 'Facture', mandatory: false, children: [
+            { type: :integer_number, libelle: 'Prix HT' },
+          ],
+        },
       ]
     end
     let(:revision) { procedure.draft_revision }


### PR DESCRIPTION
## Contexte

Permet à une formule placée **hors** d'un bloc répétable d'**agréger** un sous-champ de toutes ses lignes — besoin remonté par 6 cas du catalogue d'usage (FIPTH, perliculture, etc.). Cf. `docs/superpowers/specs/2026-05-21-formule-repetitions-design.md`.

Dépend de #452 (sous-champs PF en JSONPathColumn), mergée dans devpf.

## Ce que ça apporte (côté admin)

Nouvelles syntaxes dans l'éditeur de formule :
- `NB({Lignes de facture})` — nombre de lignes
- `SOMME({Lignes de facture/Prix HT})` — somme d'un sous-champ sur toutes les lignes (idem `MOYENNE`, `MIN`, `MAX`, `MEDIANE`)
- `JOINDRE({Partenaires/Raison sociale}, ", ")` — agrégat **texte**
- combinaisons : `SOMME({Factures/Montant}) - SOMME({Paiements/Montant})`
- agrégat d'une **formule-ligne** (transformation par ligne puis somme extérieure)

Contrainte : la formule-agrégat doit être placée **après** le bloc (validée à l'enregistrement).

## Détail technique

| Étape | Contenu |
|---|---|
| **A** | `FormulaColumnResolver` reconnaît `{tdc<bloc>}` et `{tdc<bloc>/sub_<id>}` (structs `RepetitionRef`/`RepetitionSubChampRef`) |
| **B** | `FormulaCalculationService` : `extract_repetition_row_ids` / `extract_repetition_values` (lignes vivantes, coercition type-aware, formules-ligne recalculées à la volée) |
| **C** | validation placement (réutilise `forward_reference?`) |
| **D** | dépendances niveau bloc dans `formule_deps` |
| **E** | cascade de recalcul (propagation au bloc parent ; ajout/suppression/modif de ligne) |
| **G** | éditeur admin : colonnes bloc, validateur, dédoublonnage ligne/agrégat, affichage `{Bloc/Sous-champ}`, autocomplete des sous-chemins |
| **H** | alias FR : `NB`/`COMPTE`, `RACINE`, `PLANCHER`, `PLAFOND`, `MEDIANE`, `JOINDRE` |
| **F** | doc IA (`FormulaAiPromptService`) : section agrégation + nouvelles fonctions |

Sentinelle Dentaku 3.5.4 (`spec/lib/dentaku_array_functions_spec.rb`) : verrouille SUM/COUNT/MAX/MIN/AVG sur arrays.

## Tests

- 279 exemples sur le périmètre formule (resolver, calcul, expression, validateur, prompt IA, cascade, composant éditeur)
- **Système Capybara** S5 (affichage agrégat) + S6 (recalcul sur modification via l'UI réelle, sur un agrégat de **formule-ligne**)
- rubocop global clean

## Limitation connue / dette assumée

L'agrégat d'une **formule-ligne** non persistée est recalculé à la volée par ligne (workaround) — `value_overrides` étant keyé par `stable_id` (row-aveugle). À remplacer par une **passe accumulante keyée `(stable_id, row_id)`** : design dans `docs/superpowers/specs/2026-05-28-formule-passe-accumulante-design.md`, PR de refonte à suivre (S6 servira de test opérationnel).

## Hors scope (PR séparées)
- Référentiel de Polynésie (clés value_json jsonpath, à aligner sur l'upstream `Referentiel`)
- DN `value` = numéro seul (retirer le packing array legacy)
- Syntaxe 3-segments `{Bloc/Champ/Path}` (agréger un sous-chemin de sous-champ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)