### PR TITLE
fix(sentry): ignorer les AbortError de requêtes fetch annulées

### DIFF
--- a/app/javascript/shared/track/sentry.ts
+++ b/app/javascript/shared/track/sentry.ts
@@ -25,7 +25,13 @@ if (enabled && key) {
       "'get' on proxy: property 'javaEnabled' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value",
 
       // La gaufre script often triggers an error while loading other dependencies
-      'NetworkError when attempting to fetch resource. (integration.lasuite.numerique.gouv.fr)'
+      'NetworkError when attempting to fetch resource. (integration.lasuite.numerique.gouv.fr)',
+
+      // Fetch request aborted by the user (navigation, tab close) or by an
+      // explicit AbortController (e.g. AutosaveController#disconnect). Expected
+      // behaviour, not a bug.
+      'AbortError',
+      'The user aborted a request.'
     ]
   });
 


### PR DESCRIPTION
## Contexte

- Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-310
- Titre : `Error: AbortError: The user aborted a request.`
- Occurrences (24h) : 14
- Environnement : production
- Tag Sentry : `handled: yes`

## Analyse

L'erreur `AbortError: The user aborted a request.` (DOMException code 20) est une erreur navigateur standard émise lorsqu'une requête `fetch()` est annulée — soit par un `AbortController.abort()` explicite, soit par le navigateur lors d'une navigation ou de la fermeture d'un onglet.

Dans mes-demarches, `AutosaveController` (`app/javascript/controllers/autosave_controller.ts`) utilise un `AbortController` qu'il appelle dans `disconnect()` lorsque le contrôleur Stimulus se déconnecte : c'est le comportement attendu et voulu. La fonction `httpRequest()` de `app/javascript/shared/utils.ts` combine par ailleurs `AbortSignal.timeout()` avec le signal de l'autosave, ce qui peut également produire un `AbortError` si l'usager navigue pendant une sauvegarde.

L'erreur était capturée par Sentry car elle n'était pas présente dans la liste `ignoreErrors` de `app/javascript/shared/track/sentry.ts`. C'est du bruit non actionnable côté code, au même titre que les entrées déjà filtrées (La gaufre, Piwik/Matomo, etc.).

## Fix

Ajout de `'AbortError'` et `'The user aborted a request.'` dans la liste `ignoreErrors` de `Sentry.init()`, avec un commentaire explicitant la raison, exactement comme les autres entrées de bruit déjà filtrées.

Fichier touché :
- `app/javascript/shared/track/sentry.ts`

## Test plan

- [ ] CI verte
- [ ] Vérification manuelle : les erreurs `AbortError: The user aborted a request.` ne remontent plus dans Sentry après déploiement
- [ ] Aucun tag `# pf:` touché (le fichier n'en contient aucun)

🤖 PR generee automatiquement par claude sentry-triage
