### PR TITLE
fix(sentry): forcer le format HTML pour GraphQL playground

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -9,6 +9,6 @@ class GraphqlController < ApplicationController
     }.compact.to_json
     gon.default_query = API::V2::StoredQuery.get('ds-query-v2')
 
-    render :playground, layout: false
+    render :playground, layout: false, formats: [:html]
   end
 end


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-32Q
Occurrences (24h) : 5
Environnement : production

## Analyse
L'action `GraphqlController#playground` fait `render :playground, layout: false` sans préciser le format. Quand une requête GET /graphql arrive avec `Accept: application/json`, Rails recherche un template `playground.json.*` qui n'existe pas, causant un `ActionView::MissingTemplate`. Le template HTML existe bien mais n'est pas sélectionné.

## Fix
Force le format `:html` dans le render de l'action playground pour qu'elle serve toujours le template HTML quel que soit le header Accept de la requête.

## Test plan
- [ ] CI verte
- [ ] Vérification manuelle par un humain : GET /graphql doit afficher le playground HTML même avec Accept: application/json
- [ ] Aucun impact sur les spécificités PF (aucun tag # pf: touché)

---
🤖 PR générée automatiquement par claude sentry-triage