### PR TITLE
fix(sentry): nil guard sur referentiel dans ReferentielComponent

### DIFF
--- a/app/components/editable_champ/referentiel_component/referentiel_component.html.haml
+++ b/app/components/editable_champ/referentiel_component/referentiel_component.html.haml
@@ -1,6 +1,6 @@
 - if exact_match?
   = @form.text_field :external_id, input_opts(id: @champ.focusable_input_id, required: @champ.required?, class: "width-33-desktop fr-input", novalidate: 'true', aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" })
-- else
+- elsif referentiel.present?
   .fr-input-group.address-ban
     %react-fragment
       = render ReactComponent.new "ComboBox/RemoteComboBox", **react_autocomplete_props do

--- a/spec/components/editable_champ/referentiel_component_spec.rb
+++ b/spec/components/editable_champ/referentiel_component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe EditableChamp::ReferentielComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:tdc) { procedure.active_revision.types_de_champ.first }
+  let(:champ) { dossier.champs.first }
+
+  subject do
+    component = nil
+    ActionView::Base.empty.form_for(champ, url: '/') do |form|
+      component = EditableChamp::EditableChampComponent.new(champ:, form:)
+    end
+    render_inline(component)
+  end
+
+  # Régression MES-DEMARCHES-36W : à l'aperçu d'une procédure dont le champ
+  # référentiel n'est pas encore configuré, type_de_champ.referentiel est nil.
+  # Le composant tombait dans la branche `else` et appelait referentiel.id → 500.
+  context 'when the referentiel is not configured (referentiel is nil)' do
+    it 'does not raise and renders no autocomplete' do
+      expect(tdc.referentiel).to be_nil
+
+      expect { subject }.not_to raise_error
+      expect(page).to have_no_css('react-component')
+    end
+  end
+end


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-36W
Occurrences (24h) : 1
Environnement : production

## Analyse
Dans `EditableChamp::ReferentielComponent`, `referentiel` est délégué à `type_de_champ`. À l'aperçu (`Administrateurs::ProceduresController#apercu`) d'une procédure dont le champ référentiel n'est **pas encore configuré**, `type_de_champ.referentiel` est nil. `exact_match?` (délégué `allow_nil`) renvoie alors nil → on tombe dans la branche `else`, qui appelle `react_autocomplete_props` → `referentiel.id` → `NoMethodError` (500). Stack confirmée.

## Fix
Branche `- else` remplacée par `- elsif referentiel.present?` : si le référentiel n'est pas configuré, le champ ne rend simplement pas son autocomplete en aperçu (dégradation acceptable), au lieu de planter.

## Test plan
- [x] Spec de régression `spec/components/editable_champ/referentiel_component_spec.rb` (rouge sans le guard, verte avec)
- [x] Rubocop clean
- [ ] CI verte
- [ ] Vérification manuelle par un humain
- [ ] Aucun impact sur les spécificités PF (aucun tag # pf: touché)

---
🤖 PR générée automatiquement par claude sentry-triage