### PR TITLE
fix(sentry): nil check sur @attachment dans AttachmentsController#destroy

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -19,6 +19,8 @@ class AttachmentsController < ApplicationController
   end
 
   def destroy
+    return head(:not_found) if @attachment.nil?
+
     if champ?
       @attachment = champ.piece_justificative_file.find { _1.blob.id == @blob.id }
       if @attachment.present?
@@ -93,7 +95,7 @@ class AttachmentsController < ApplicationController
     avis? && current_expert == record.expert
   end
 
-  def record = @attachment.record
+  def record = @attachment&.record
   def champ? = record.is_a?(Champ)
   def procedure? = record.is_a?(Procedure)
   def avis? = record.is_a?(Avis)

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -19,9 +19,11 @@ class AttachmentsController < ApplicationController
   end
 
   def destroy
-    return head(:not_found) if @attachment.nil?
-
     if champ?
+      # `find` avec bloc (Enumerable) renvoie nil si le blob ciblé n'est plus
+      # parmi les PJ du champ courant (ex: suppression « stale » sur le champ
+      # buffer en_construction, double-clic). On réassigne donc @attachment à
+      # nil ici ; `record` doit rester nil-safe pour les appels qui suivent.
       @attachment = champ.piece_justificative_file.find { _1.blob.id == @blob.id }
       if @attachment.present?
         champ.reset_external_data!

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -83,6 +83,26 @@ describe AttachmentsController, type: :controller do
         end
       end
 
+      # Régression MES-DEMARCHES-371 : en en_construction, la suppression passe par
+      # le champ buffer. Une 2e suppression « stale » (double-clic) retrouve encore
+      # l'attachment public via set_attachment, mais le buffer ne contient plus le
+      # blob → le find-bloc (Enumerable) renvoie nil. `record` doit rester nil-safe,
+      # sinon `champ?` planterait (NoMethodError sur nil) → 500.
+      context 'and the blob was already removed from the buffer (stale double delete)' do
+        let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, user:, procedure:) }
+
+        it 'returns 200 on the second delete instead of crashing' do
+          perform_enqueued_jobs do
+            delete :destroy, params: { id: attachment.id, signed_id:, dossier_id: dossier.id, stable_id: champ.stable_id }, format: :turbo_stream
+          end
+          expect(response).to have_http_status(200)
+          expect(user_buffer_champ.piece_justificative_file.attached?).to be(false)
+
+          delete :destroy, params: { id: attachment.id, signed_id:, dossier_id: dossier.id, stable_id: champ.stable_id }, format: :turbo_stream
+          expect(response).to have_http_status(200)
+        end
+      end
+
       context 'and signed_id is invalid' do
         let(:signed_id) { 'yolo' }
 


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/MES-DEMARCHES-371
Occurrences (24h) : 1
Environnement : production

## Analyse (corrigée)
> ⚠️ L'analyse initiale (« @attachment peut être nil dans set_attachment ») était **fausse** : `set_attachment` fait `@blob.attachments.find(params[:id])`, qui lève `RecordNotFound` (→ 404) si l'id est absent, et ne renvoie **jamais** nil. À l'entrée de `destroy`, `@attachment` n'est donc jamais nil.

Vraie cause, confirmée par la stack (crash **ligne 45**, pas à l'entrée) :
- En `en_construction`, `champ` résout vers le champ **buffer** (`champ_for_update`), distinct du champ public porteur de l'attachment.
- Ligne `@attachment = champ.piece_justificative_file.find { _1.blob.id == @blob.id }` utilise `Enumerable#find` **avec bloc** → renvoie **nil** quand le blob ciblé n'est plus parmi les PJ du buffer (suppression « stale » / double-clic : la 1ʳᵉ suppression a déjà purgé la PJ du buffer, mais l'attachment public reste retrouvable par `set_attachment`).
- L'appel ultérieur `champ?` → `record` → `@attachment.record` plante alors sur nil (`NoMethodError`).

## Fix
- Suppression du guard mort `return head(:not_found) if @attachment.nil?` (ne couvrait pas le bug).
- Correctif effectif conservé : `def record = @attachment&.record` (rend les prédicats `champ?`/`procedure?`/… nil-safe ; le bloc `ChampRevision` est alors proprement sauté).
- Commentaire ajouté près du `find` pour documenter le mécanisme.
- **Spec de régression non-stubée** (`spec/controllers/attachments_controller_spec.rb`) : reproduit le double-delete `en_construction`. Vérifiée rouge sans `&.` (même 500 que la prod), verte avec.

## Test plan
- [x] Spec de régression rouge→verte
- [x] Suite `attachments_controller_spec` complète verte (17 ex.)
- [x] Rubocop clean
- [ ] Vérification manuelle par un humain
- [ ] Aucun impact sur les spécificités PF (aucun tag # pf: touché)

---
🤖 PR générée automatiquement par claude sentry-triage, analyse corrigée après revue